### PR TITLE
Support for one-pass mode.

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -29,6 +29,8 @@
 #     A unique port for which the balancer member will accept connections
 #     from the load balancer. Note that cookie values aren't yet supported,
 #     but shouldn't be difficult to add to the configuration.
+#     If you use an array in server_name and balancer_ip, the same port is
+#     used for all balancermembers.
 #
 # [*order*]
 #     The order, or numerical weight, of the fragment created by this defined
@@ -38,10 +40,13 @@
 # [*server_name*]
 #     The name of the balancer member server as known to haproxy in the
 #      listening service's configuration block. This defaults to the
-#      hostname
+#      hostname. Can be an array of the same length as balancer_ip,
+#      in which case a balancermember is created for each pair of
+#      server_name and balancer_ip (in lockstep).
 #
 # [*balancer_ip*]
-#      The ip address used to contact the balancer member server
+#      The ip address used to contact the balancer member server.
+#      Can be an array, see documentation to server_name.
 #
 # [*balancermember_options*]
 #      An array of options to be specified after the server declaration
@@ -65,6 +70,21 @@
 #  Collecting the resource on a load balancer
 #
 #  Haproxy::Balancermember <<| listening_service == 'puppet00' |>>
+#
+#  Creating the resource for multiple balancer members at once
+#  (for single-pass installation of haproxy without requiring a first
+#  pass to export the resources if you know the members in advance):
+# 
+#  haproxy::balancermember { 'haproxy':
+#    listening_service      => 'puppet00',
+#    balancer_port          => '8140',
+#    order                  => '21',
+#    server_name            => ['server01', 'server02'],
+#    balancer_ip            => ['192.168.56.200', '192.168.56.201'],
+#    balancermember_options => 'check',
+#  }
+#  
+#  (this resource can be declared anywhere)
 #
 # === Authors
 #

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,7 +40,14 @@
 # [*haproxy_config_options*]
 #    A hash of options that are inserted into the listening service
 #     configuration block.
-#
+# 
+# [*collect_exported*]
+#    Boolean, default 'true'. True means 'collect exported @@balancermember resources'
+#    (for the case when every balancermember node exports itself), false means
+#    'rely on the existing declared balancermember resources' (for the case when you 
+#    know the full set of balancermembers in advance and use haproxy::balancermember 
+#    with array arguments, which allows you to deploy everything in 1 run)
+#    
 #
 # === Examples
 #
@@ -67,6 +74,7 @@ define haproxy::config (
   $haproxy_config_options    = {'option' => ['tcplog',
                                             'ssl-hello-chk'],
                                 'balance' => 'roundrobin'},
+  $collect_exported          = true,
 ) {
   concat::fragment { "${name}_config_block":
     order   => $order,
@@ -74,5 +82,9 @@ define haproxy::config (
     content => template('haproxy/haproxy_config_block.erb'),
   }
 
-  Haproxy::Balancermember <<| listening_service == $name |>>
+  if $collect_exported {
+    Haproxy::Balancermember <<| listening_service == $name |>>
+  }
+  # else: the resources have been created and they introduced their
+  # concat fragments. We don't have to do anything about them.
 }

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -20,7 +20,7 @@ describe 'haproxy::balancermember' do
     it { should contain_concat__fragment('croy_balancermember_tyler').with(
       'order'   => '20',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "  server  dero 1.1.1.1:18140  check\n"
+      'content' => "  server  dero 1.1.1.1:18140  check\n\n"
       ) }
   end
 
@@ -36,7 +36,25 @@ describe 'haproxy::balancermember' do
     it { should contain_concat__fragment('croy_balancermember_tyler').with(
       'order'   => '20',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "  server  dero 1.1.1.1:18140  check close\n"
+      'content' => "  server  dero 1.1.1.1:18140  check close\n\n"
+      ) }
+  end
+
+  context 'with multiple servers' do
+    let(:params) do
+      { :name                   => 'tyler',
+        :listening_service      => 'croy',
+        :balancer_port          => '18140',
+        :server_name            => ['server01', 'server02'],
+        :balancer_ip            => ['192.168.56.200', '192.168.56.201'],
+        :balancermember_options => ['check']
+      }
+    end
+
+    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+      'order'   => '20',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "  server  server01 192.168.56.200:18140  check\n  server  server02 192.168.56.201:18140  check\n\n"
       ) }
   end
 end

--- a/templates/haproxy_balancermember.erb
+++ b/templates/haproxy_balancermember.erb
@@ -1,4 +1,5 @@
-  server  <%= server_name %> <%= balancer_ip %>:<%= balancer_port %> <%
+<% for @ip,@host in Array(@balancer_ip).zip(Array(@server_name)) %>  server  <%= @host %> <%= @ip %>:<%= balancer_port %> <%
     items = balancermember_options
     items = [items] unless balancermember_options.instance_of? Array
     items.each do |item| %> <%= item %><% end %>
+<% end %>


### PR DESCRIPTION
This allows you to configure haproxy in 1 puppet run in case you know the set of balancermembers in advance, without requiring a first run to export the resources.
