### PR TITLE
Release 0.1.1

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-haproxy'
-version '0.1.0'
+version '0.1.1'
 source 'git://github.com/puppetlabs/puppetlabs-haproxy'
 author 'Puppet Labs'
 license 'Apache License, Version 2.0'


### PR DESCRIPTION
Bugfix to fix module name for puppetlabs namespace before uploading to the forge.
