### PR TITLE
Add manage_service parameter for corosync

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,7 @@
 # Gary Larizza <gary@puppetlabs.com>
 #
 class haproxy (
+  $manage_service           = true,
   $enable                   = true,
   $haproxy_global_options   = $haproxy::data::haproxy_global_options,
   $haproxy_defaults_options = $haproxy::data::haproxy_defaults_options
@@ -116,21 +117,23 @@ class haproxy (
 
   }
 
-  service { 'haproxy':
-    ensure     => $enable ? {
-      true  => running,
-      false => stopped,
-    },
-    enable     => $enable ? {
-      true  => true,
-      false => false,
-    },
-    name       => 'haproxy',
-    hasrestart => true,
-    hasstatus  => true,
-    require    => [
-      Concat['/etc/haproxy/haproxy.cfg'],
-      File[$haproxy_global_options['chroot']],
-    ],
+  if $manage_service {
+    service { 'haproxy':
+      ensure     => $enable ? {
+        true  => running,
+        false => stopped,
+      },
+      enable     => $enable ? {
+        true  => true,
+        false => false,
+      },
+      name       => 'haproxy',
+      hasrestart => true,
+      hasstatus  => true,
+      require    => [
+        Concat['/etc/haproxy/haproxy.cfg'],
+        File[$haproxy_global_options['chroot']],
+      ],
+    }
   }
 }

--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -83,6 +83,26 @@ describe 'haproxy', :type => :class do
             end
           end
         end
+        context "on #{osfamily} family operatingsystems without managing the service" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'enable'         => true,
+              'manage_service' => false,
+            }
+          end
+          it { should include_class('concat::setup') }
+          it 'should install the haproxy package' do
+            subject.should contain_package('haproxy').with(
+              'ensure' => 'present'
+            )
+          end
+          it 'should install the haproxy service' do
+            subject.should_not contain_service('haproxy')
+          end
+        end
       end
     end
     describe 'for OS-specific configuration' do


### PR DESCRIPTION
Corosync needs to be the one managing the haproxy service, not puppet. This attribute allows that to happen.
