### PR TITLE
Rename `haproxy_config_options` parameter to `config_options`

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,7 +38,7 @@
 #    The mode of operation for the listening service. Valid values are 'tcp',
 #     HTTP', and 'health'.
 #
-# [*haproxy_config_options*]
+# [*config_options*]
 #    A hash of options that are inserted into the listening service
 #     configuration block.
 #
@@ -69,11 +69,11 @@
 #
 define haproxy::config (
   $ports,
-  $order                     = '20',
-  $virtual_ip                = $::ipaddress,
-  $mode                      = 'tcp',
-  $collect_exported          = true,
-  $haproxy_config_options    = {
+  $order            = '20',
+  $virtual_ip       = $::ipaddress,
+  $mode             = 'tcp',
+  $collect_exported = true,
+  $config_options   = {
     'option' => [
       'tcplog',
       'ssl-hello-chk'

--- a/templates/haproxy_config_block.erb
+++ b/templates/haproxy_config_block.erb
@@ -1,6 +1,6 @@
 
 listen <%= name %> <%= virtual_ip %>:<%= Array(ports).join(",#{virtual_ip}:") %>
-<% haproxy_config_options.sort.each do |key, val| -%>
+<% config_options.sort.each do |key, val| -%>
 <% if val.is_a?(Array) -%>
 <% val.each do |item| -%>
   <%= key %>  <%= item %>


### PR DESCRIPTION
For great sanity.

Built on #10
