### PR TITLE
Rename everything!

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -22,8 +22,8 @@
 #
 # [*listening_service*]
 #    The haproxy service's instance name (or, the title of the
-#     haproxy::config resource). This must match up with a declared
-#     haproxy::config resource.
+#     haproxy::listen resource). This must match up with a declared
+#     haproxy::listen resource.
 #
 # [*balancer_port*]
 #     A unique port for which the balancer member will accept connections

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# == Class: puppet-haproxy
+# == Class: haproxy
 #
 # A Puppet module, using storeconfigs, to model an haproxy configuration.
 # Currently VERY limited - assumes Redhat/CentOS setup. Pull requests accepted!
@@ -15,13 +15,13 @@
 #   Chooses whether haproxy should be installed or ensured absent.
 #   Currently ONLY accepts valid boolean true/false values.
 #
-# [*haproxy_global_options*]
+# [*global_options*]
 #   A hash of all the haproxy global options. If you want to specify more
 #    than one option (i.e. multiple timeout or stats options), pass those
 #    options as an array and you will get a line for each of them in the
 #    resultant haproxy.cfg file.
 #
-# [*haproxy_defaults_options*]
+# [*defaults_options*]
 #   A hash of all the haproxy defaults options. If you want to specify more
 #    than one option (i.e. multiple timeout or stats options), pass those
 #    options as an array and you will get a line for each of them in the
@@ -31,8 +31,8 @@
 # === Examples
 #
 #  class { 'haproxy':
-#    enable                   => true,
-#    haproxy_global_options   => {
+#    enable           => true,
+#    global_options   => {
 #      'log'     => "${::ipaddress} local0",
 #      'chroot'  => '/var/lib/haproxy',
 #      'pidfile' => '/var/run/haproxy.pid',
@@ -42,7 +42,7 @@
 #      'daemon'  => '',
 #      'stats'   => 'socket /var/lib/haproxy/stats'
 #    },
-#    haproxy_defaults_options => {
+#    defaults_options => {
 #      'log'     => 'global',
 #      'stats'   => 'enable',
 #      'option'  => 'redispatch',
@@ -59,16 +59,12 @@
 #    },
 #  }
 #
-# === Authors
-#
-# Gary Larizza <gary@puppetlabs.com>
-#
 class haproxy (
-  $manage_service           = true,
-  $enable                   = true,
-  $haproxy_global_options   = $haproxy::data::haproxy_global_options,
-  $haproxy_defaults_options = $haproxy::data::haproxy_defaults_options
-) inherits haproxy::data {
+  $manage_service   = true,
+  $enable           = true,
+  $global_options   = $haproxy::params::global_options,
+  $defaults_options = $haproxy::params::defaults_options
+) inherits haproxy::params {
   include concat::setup
 
   package { 'haproxy':
@@ -95,7 +91,7 @@ class haproxy (
       content => "# This file managed by Puppet\n",
     }
 
-    # Most of the variables are used inside the haproxy-base.cfg.erb template
+    # Template uses $global_options, $defaults_options
     concat::fragment { 'haproxy-base':
       target  => '/etc/haproxy/haproxy.cfg',
       order   => '10',
@@ -110,7 +106,7 @@ class haproxy (
       }
     }
 
-    file { $haproxy_global_options['chroot']:
+    file { $global_options['chroot']:
       ensure => directory,
       before => Service['haproxy'],
     }
@@ -132,7 +128,7 @@ class haproxy (
       hasstatus  => true,
       require    => [
         Concat['/etc/haproxy/haproxy.cfg'],
-        File[$haproxy_global_options['chroot']],
+        File[$global_options['chroot']],
       ],
     }
   }

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -1,4 +1,4 @@
-# == Define Resource Type: haproxy::config
+# == Define Resource Type: haproxy::listen
 #
 # This type will setup a listening service configuration block inside
 #  the haproxy.cfg file on an haproxy load balancer. Each listening service
@@ -30,7 +30,7 @@
 #     resource type. This is necessary to ensure the fragment is associated
 #     with the correct listening service instance.
 #
-# [*listen_ip*]
+# [*ipaddress*]
 #    The ip address the proxy binds to. Empty addresses, '*', and '0.0.0.0'
 #     mean that the proxy listens to all valid addresses on the system.
 #
@@ -38,7 +38,7 @@
 #    The mode of operation for the listening service. Valid values are 'tcp',
 #     HTTP', and 'health'.
 #
-# [*config_options*]
+# [*options*]
 #    A hash of options that are inserted into the listening service
 #     configuration block.
 #
@@ -54,12 +54,12 @@
 #
 #  Exporting the resource for a balancer member:
 #
-#  haproxy::config { 'puppet00':
-#    order          => '20',
-#    listen_ip      => $::ipaddress,
-#    ports          => '18140',
-#    mode           => 'tcp',
-#    config_options => {
+#  haproxy::listen { 'puppet00':
+#    order     => '20',
+#    ipaddress => $::ipaddress,
+#    ports     => '18140',
+#    mode      => 'tcp',
+#    options   => {
 #      'option'  => [
 #        'tcplog',
 #        'ssl-hello-chk'
@@ -72,13 +72,13 @@
 #
 # Gary Larizza <gary@puppetlabs.com>
 #
-define haproxy::config (
+define haproxy::listen (
   $ports,
   $order            = '20',
-  $listen_ip       = $::ipaddress,
+  $ipaddress        = $::ipaddress,
   $mode             = 'tcp',
   $collect_exported = true,
-  $config_options   = {
+  $options          = {
     'option'  => [
       'tcplog',
       'ssl-hello-chk'
@@ -86,10 +86,11 @@ define haproxy::config (
     'balance' => 'roundrobin'
   }
 ) {
-  concat::fragment { "${name}_config_block":
+  # Template uses: $name, $ipaddress, $ports, $options
+  concat::fragment { "${name}_listen_block":
     order   => $order,
     target  => '/etc/haproxy/haproxy.cfg',
-    content => template('haproxy/haproxy_config_block.erb'),
+    content => template('haproxy/haproxy_listen_block.erb'),
   }
 
   if $collect_exported {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,13 +1,13 @@
-# == Class: haproxy::data
+# == Class: haproxy::params
 #
 # This is a container class holding default parameters for for haproxy class.
 #  currently, only the Redhat family is supported, but this can be easily
 #  extended by changing package names and configuration file paths.
 #
-class haproxy::data {
+class haproxy::params {
   case $osfamily {
     Redhat: {
-      $haproxy_global_options   = {
+      $global_options   = {
         'log'     => "${::ipaddress} local0",
         'chroot'  => '/var/lib/haproxy',
         'pidfile' => '/var/run/haproxy.pid',
@@ -17,7 +17,7 @@ class haproxy::data {
         'daemon'  => '',
         'stats'   => 'socket /var/lib/haproxy/stats'
       }
-      $haproxy_defaults_options = {
+      $defaults_options = {
         'log'     => 'global',
         'stats'   => 'enable',
         'option'  => 'redispatch',
@@ -34,7 +34,7 @@ class haproxy::data {
       }
     }
     Debian: {
-      $haproxy_global_options   = {
+      $global_options   = {
         'log'     => "${::ipaddress} local0",
         'chroot'  => '/var/lib/haproxy',
         'pidfile' => '/var/run/haproxy.pid',
@@ -44,7 +44,7 @@ class haproxy::data {
         'daemon'  => '',
         'stats'   => 'socket /var/lib/haproxy/stats'
       }
-      $haproxy_defaults_options = {
+      $defaults_options = {
         'log'     => 'global',
         'stats'   => 'enable',
         'option'  => 'redispatch',

--- a/spec/defines/listen_spec.rb
+++ b/spec/defines/listen_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'haproxy::config' do
+describe 'haproxy::listen' do
   let(:title) { 'tyler' }
   let(:facts) {{ :ipaddress => '1.1.1.1' }}
   context "when only one port is provided" do
@@ -10,7 +10,7 @@ describe 'haproxy::config' do
       }
     end
 
-    it { should contain_concat__fragment('croy_config_block').with(
+    it { should contain_concat__fragment('croy_listen_block').with(
       'order'   => '20',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten croy 1.1.1.1:18140\n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
@@ -19,7 +19,7 @@ describe 'haproxy::config' do
   context "when an array of ports is provided" do
     let(:params) do
       { :name      => 'apache',
-        :listen_ip => '23.23.23.23',
+        :ipaddress => '23.23.23.23',
         :ports     => [
           '80',
           '443',
@@ -27,7 +27,7 @@ describe 'haproxy::config' do
       }
     end
 
-    it { should contain_concat__fragment('apache_config_block').with(
+    it { should contain_concat__fragment('apache_listen_block').with(
       'order'   => '20',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten apache 23.23.23.23:80,23.23.23.23:443\n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"

--- a/templates/haproxy-base.cfg.erb
+++ b/templates/haproxy-base.cfg.erb
@@ -1,5 +1,5 @@
 global
-<% haproxy_global_options.sort.each do |key,val| -%>
+<% global_options.sort.each do |key,val| -%>
 <% if val.is_a?(Array) -%>
 <% val.each do |item| -%>
   <%= key %>  <%= item %>
@@ -10,7 +10,7 @@ global
 <% end -%>
 
 defaults
-<% haproxy_defaults_options.sort.each do |key,val| -%>
+<% defaults_options.sort.each do |key,val| -%>
 <% if val.is_a?(Array) -%>
 <% val.each do |item| -%>
   <%= key %>  <%= item %>

--- a/templates/haproxy_listen_block.erb
+++ b/templates/haproxy_listen_block.erb
@@ -1,6 +1,6 @@
 
-listen <%= name %> <%= listen_ip %>:<%= Array(ports).join(",#{listen_ip}:") %>
-<% config_options.sort.each do |key, val| -%>
+listen <%= name %> <%= ipaddress %>:<%= Array(ports).join(",#{ipaddress}:") %>
+<% options.sort.each do |key, val| -%>
 <% if val.is_a?(Array) -%>
 <% val.each do |item| -%>
   <%= key %>  <%= item %>

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,31 +1,35 @@
 # Declare haproxy base class with configuration options
 class { 'haproxy':
-  enable                   => true,
-  haproxy_global_options   => {'log'      => "${::ipaddress} local0",
-                                'chroot'  => '/var/lib/haproxy',
-                                'pidfile' => '/var/run/haproxy.pid',
-                                'maxconn' => '4000',
-                                'user'    => 'haproxy',
-                                'group'   => 'haproxy',
-                                'daemon'  => '',
-                                'stats'   => 'socket /var/lib/haproxy/stats'
-                              },
-  haproxy_defaults_options => {'log'      => 'global',
-                                'stats'   => 'enable',
-                                'option'  => 'redispatch',
-                                'retries' => '3',
-                                'timeout' => ['http-request 10s',
-                                'queue 1m',
-                                'connect 10s',
-                                'client 1m',
-                                'server 1m',
-                                'check 10s'],
-                                'maxconn' => '8000'
-                              },
+  enable           => true,
+  global_options   => {
+    'log'     => "${::ipaddress} local0",
+    'chroot'  => '/var/lib/haproxy',
+    'pidfile' => '/var/run/haproxy.pid',
+    'maxconn' => '4000',
+    'user'    => 'haproxy',
+    'group'   => 'haproxy',
+    'daemon'  => '',
+    'stats'   => 'socket /var/lib/haproxy/stats',
+  },
+  defaults_options => {
+    'log'     => 'global',
+    'stats'   => 'enable',
+    'option'  => 'redispatch',
+    'retries' => '3',
+    'timeout' => [
+      'http-request 10s',
+      'queue 1m',
+      'connect 10s',
+      'client 1m',
+      'server 1m',
+      'check 10s',
+    ],
+    'maxconn' => '8000',
+  },
 }
 
 # Export a balancermember server, note that the listening_service parameter
-#  will/must correlate with an haproxy::config defined resource type.
+#  will/must correlate with an haproxy::listen defined resource type.
 @@haproxy::balancermember { $fqdn:
   order                  => '21',
   listening_service      => 'puppet00',
@@ -39,18 +43,27 @@ class { 'haproxy':
 #  Note that the balancermember server resources are being collected in
 #  the haproxy::config defined resource type with the following line:
 #  Haproxy::Balancermember <<| listening_service == $name |>>
-haproxy::config { 'puppet00':
-  order                  => '20',
-  virtual_ip             => $::ipaddress,
-  virtual_ip_port        => '18140',
-  haproxy_config_options => {
-    'option' => ['tcplog', 'ssl-hello-chk'], 'balance' => 'roundrobin' },
+haproxy::listen { 'puppet00':
+  order     => '20',
+  ipaddress => $::ipaddress,
+  ports     => '18140',
+  options   => {
+    'option'  => [
+      'tcplog',
+      'ssl-hello-chk',
+    ],
+    'balance' => 'roundrobin',
+  },
 }
-haproxy::config { 'stats':
-  order                  => '30',
-  virtual_ip             => '',
-  virtual_ip_port        => '9090',
-  haproxy_config_options => { 'mode'  => 'http',
-                              'stats' => ['uri /', 'auth puppet:puppet']
+haproxy::listen { 'stats':
+  order     => '30',
+  ipaddress => '',
+  ports     => '9090',
+  options   => {
+    'mode'  => 'http',
+    'stats' => [
+      'uri /',
+      'auth puppet:puppet'
+    ],
   },
 }


### PR DESCRIPTION
What is renamed:
- Class/define:
  - haproxy::config to haproxy::listen
  - haproxy::data to haproxy::params
- Parameters:
  - haproxy::listen listen_ip to ipaddress
  - haproxy::listen config_options to options
  - haproxy haproxy_global_options to global_options
  - haproxy haproxy_defaults_options to defaults_options

Also a few small whitespace & docs changes for the forge.
