### PR TITLE
Use selector for haproxy service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,10 @@ class haproxy (
       group   => '0',
       mode    => '0644',
       require => Package['haproxy'],
-      notify  => Service['haproxy'],
+      notify  => $manage_service ? {
+        true  => Service['haproxy'],
+        false => undef,
+      },
     }
 
     # Simple Header
@@ -102,13 +105,15 @@ class haproxy (
       file { '/etc/default/haproxy':
         content => 'ENABLED=1',
         require => Package['haproxy'],
-        before  => Service['haproxy'],
+        before  => $manage_service ? {
+          true  => Service['haproxy'],
+          false => undef,
+        },
       }
     }
 
     file { $global_options['chroot']:
       ensure => directory,
-      before => Service['haproxy'],
     }
 
   }


### PR DESCRIPTION
There are no spec tests to verify dependencies on a successful compilation, so I missed this.
