### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,5 @@
+2012-10-12 - Version 0.2.0
+- Initial public release
+- Backwards incompatible changes all around
+- No longer needs ordering passed for more than one listener
+- Accepts multiple listen ips/ports/server_names

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-haproxy'
-version '0.1.1'
+version '0.2.0'
 source 'git://github.com/puppetlabs/puppetlabs-haproxy'
 author 'Puppet Labs'
 license 'Apache License, Version 2.0'


### PR DESCRIPTION
- Initial public release
- Backwards incompatible changes all around
- No longer needs ordering passed for more than one listener
- Accepts multiple listen ips/ports/server_names
