### PR TITLE
Made chroot optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,13 +112,26 @@ class haproxy (
       }
     }
 
-    file { $global_options['chroot']:
-      ensure => directory,
+    if $global_options['chroot'] {
+      file { $global_options['chroot']:
+        ensure => directory,
+      }
     }
 
   }
 
   if $manage_service {
+    if $global_options['chroot'] {
+      $deps = [
+        Concat['/etc/haproxy/haproxy.cfg'],
+        File[$global_options['chroot']],
+      ]
+    } else {
+      $deps = [
+        Concat['/etc/haproxy/haproxy.cfg'],
+      ]
+    }
+
     service { 'haproxy':
       ensure     => $enable ? {
         true  => running,
@@ -131,10 +144,7 @@ class haproxy (
       name       => 'haproxy',
       hasrestart => true,
       hasstatus  => true,
-      require    => [
-        Concat['/etc/haproxy/haproxy.cfg'],
-        File[$global_options['chroot']],
-      ],
+      require    => $deps,
     }
   }
 }


### PR DESCRIPTION
If chroot was left unspecified, the module would crash with a `File[undef]` error. There are no tests yet, but they can be added. I only needed to start logging, and removing the chroot was the quickest way for me to go forward. Enabling UDP is the real solution, which I'll later.

If making chroot optional is useless, I'll just use this until I've enabled UDP syslog, then remove this branch.
