### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+2013-05-25 - Version 0.3.0
+Features:
+- Add travis testing
+- Add `haproxy::basancermember` `define_cookies` parameter
+- Add array support to `haproxy::listen` `ipaddress` parameter
+
+Bugfixes:
+- Documentation
+- Listen -> Balancermember dependency
+- Config line ordering
+- Whitespace
+- Add template lines for `haproxy::listen` `mode` parameter
+
 2012-10-12 - Version 0.2.0
 - Initial public release
 - Backwards incompatible changes all around

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-haproxy'
-version '0.2.0'
+version '0.3.0'
 source 'git://github.com/puppetlabs/puppetlabs-haproxy'
 author 'Puppet Labs'
 license 'Apache License, Version 2.0'


### PR DESCRIPTION
Features:
- Add travis testing
- Add `haproxy::basancermember` `define_cookies` parameter
- Add array support to `haproxy::listen` `ipaddress` parameter

Bugfixes:
- Documentation
- Listen -> Balancermember dependency
- Config line ordering
- Whitespace
- Add template lines for `haproxy::listen` `mode` parameter
