### PR TITLE
Correct the order with which concat fragments of listening services are collected

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -92,7 +92,7 @@ define haproxy::balancermember (
 ) {
   # Template uses $ipaddresses, $server_name, $ports, $option
   concat::fragment { "${listening_service}_balancermember_${name}":
-    order   => "20-${listening_service}-${name}",
+    order   => "20-${listening_service}-01-${name}",
     target  => '/etc/haproxy/haproxy.cfg',
     content => template('haproxy/haproxy_balancermember.erb'),
   }


### PR DESCRIPTION
Correct the order with which concat fragments of listening services are collected. The previous implementation could result to wrong configuration files. 

Example:

Suppose you have two backend members named lxbrf23, lxbrf24 and the listening services: 
-demoservice
-demoservice-mess
-demoservice-mess-it
-demoservice-mess-it-even
-demoservice-mess-it-even-more

The concat fragments will be alphanumerically ordered and will result to a wrong configuration file.
