### PR TITLE
Only manage the chroot dir if using the chroot option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,8 +112,10 @@ class haproxy (
       }
     }
 
-    file { $global_options['chroot']:
-      ensure => directory,
+    if $global_options['chroot'] {
+      file { $global_options['chroot']:
+        ensure => directory,
+      }
     }
 
   }
@@ -131,10 +133,11 @@ class haproxy (
       name       => 'haproxy',
       hasrestart => true,
       hasstatus  => true,
-      require    => [
-        Concat['/etc/haproxy/haproxy.cfg'],
-        File[$global_options['chroot']],
-      ],
+      require    => $global_options['chroot'] ? {
+        undef   => [Concat['/etc/haproxy/haproxy.cfg']],
+        default => [Concat['/etc/haproxy/haproxy.cfg'],
+                    File[$global_options['chroot']],],
+      },
     }
   }
 }


### PR DESCRIPTION
As is the module attempts to manage an File[undef] resource if the chroot global option is not used.
