### PR TITLE
Add parameter to specify an alternate package name to install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,8 @@
 #    options as an array and you will get a line for each of them in the
 #    resultant haproxy.cfg file.
 #
+# [*package_name*]
+#   The package name to install containing haproxy.  Defaults to <code>'haproxy'</code>
 #
 # === Examples
 #
@@ -63,16 +65,17 @@ class haproxy (
   $manage_service   = true,
   $enable           = true,
   $global_options   = $haproxy::params::global_options,
-  $defaults_options = $haproxy::params::defaults_options
+  $defaults_options = $haproxy::params::defaults_options,
+  $package_name     = 'haproxy'
 ) inherits haproxy::params {
   include concat::setup
 
-  package { 'haproxy':
+  package { $package_name:
     ensure  => $enable ? {
       true  => present,
       false => absent,
     },
-    name    => 'haproxy',
+    alias   => 'haproxy',
   }
 
   if $enable {


### PR DESCRIPTION
We have built a haproxy15 package so we can use it for ssl proxy applications.  Everything else works with your module so being able to specify the name of the package to install would be very helpful.  I'm sure others have similar needs.
