### PR TITLE
Add an ensure parameter to balancermember.

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -43,6 +43,10 @@
 #      The ip address used to contact the balancer member server.
 #      Can be an array, see documentation to server_names.
 #
+# [*ensure*]
+#      If the balancermember should be present or absent.
+#      Defaults to present.
+#
 # [*options*]
 #      An array of options to be specified after the server declaration
 #       in the listening service's configuration block.
@@ -87,12 +91,14 @@ define haproxy::balancermember (
   $ports,
   $server_names = $::hostname,
   $ipaddresses  = $::ipaddress,
+  $ensure       = 'present',
   $options      = '',
   $define_cookies = false
 ) {
   # Template uses $ipaddresses, $server_name, $ports, $option
   concat::fragment { "${listening_service}_balancermember_${name}":
     order   => "20-${listening_service}-${name}",
+    ensure  => $ensure,
     target  => '/etc/haproxy/haproxy.cfg',
     content => template('haproxy/haproxy_balancermember.erb'),
   }

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -26,6 +26,24 @@ describe 'haproxy::balancermember' do
     ) }
   end
 
+  context 'with a balancermember with ensure => absent ' do
+    let(:params) do
+      {
+        :name              => 'tyler',
+        :listening_service => 'croy',
+        :ports             => '18140',
+        :ensure            => 'absent'
+      }
+    end
+
+    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+      'order'   => '20-croy-tyler',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'ensure'  => 'absent',
+      'content' => "  server dero 1.1.1.1:18140  \n"
+    ) }
+  end
+
   context 'with multiple balancermember options' do
     let(:params) do
       {


### PR DESCRIPTION
This allows backends to be removed without manipulating exported resources.

This is useful when you use exported resources and want to get rid of the balancermember without waiting for them to expire from puppetdb e.g. when taking a group of hosts out of service for a specific backend.
