### PR TITLE
Added ACLS to listen block

### DIFF
--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -54,6 +54,10 @@
 #    ipaddress => $::ipaddress,
 #    ports     => '18140',
 #    mode      => 'tcp',
+#    acls      => [
+#       'acl         web hdr_beg(host) -i www',
+#       'use_backend web if web',
+#    ],
 #    options   => {
 #      'option'  => [
 #        'tcplog',
@@ -71,6 +75,7 @@ define haproxy::listen (
   $ports,
   $ipaddress        = [$::ipaddress],
   $mode             = undef,
+  $acls             = [],
   $collect_exported = true,
   $options          = {
     'option'  => [

--- a/templates/haproxy_listen_block.erb
+++ b/templates/haproxy_listen_block.erb
@@ -11,3 +11,6 @@ listen <%= @name %>
   <%= key %>  <%= item %>
 <% end -%>
 <% end -%>
+<% @acls.each do |acl| -%>
+  <%= acl %>
+<% end -%>


### PR DESCRIPTION
Listen Blocks should include the ability to add ACL options such as

haproxy::listen { 'HTTP-Frontend':
ipaddress => '0.0.0.0',
mode => 'http',
ports => '80',
options => {
'maxconn' => '65545'
},
acls => [
'acl docs hdr_beg(host) -i docs',
'use_backend docs if docs',
'acl www hdr_beg(host) -i web',
'use_backend www if www',
],
}
