### PR TITLE
Fix tests on puppet 2.6.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,7 @@
 fixtures:
   repositories:
-    concat: "git://github.com/ripienaar/puppet-concat.git"
+    concat: 
+      repo: "git://github.com/ripienaar/puppet-concat.git"
+      ref:  "1.0.0"
   symlinks:
     haproxy: "#{source_dir}"

--- a/.gemfile
+++ b/.gemfile
@@ -2,4 +2,4 @@ source :rubygems
 
 puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
 gem 'puppet', puppetversion
-gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'puppetlabs_spec_helper', '>= 0.4.0'


### PR DESCRIPTION
Current master of concat breaks on 2.6. Use the last release instead.

Specifying a git ref requires version 0.4.0 of puppetlabs_spec_helper

NB - concat PR for syntax fix: https://github.com/puppetlabs/puppetlabs-concat/pull/72
