### PR TITLE
Allow user-defined service restart parameter.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,11 @@
 # [*package_name*]
 #   The package name to install containing haproxy.  Defaults to <code>'haproxy'</code>
 #
+#[*restart_command*]
+#   Command to use when restarting the on config changes.
+#    Passed directly as the <code>'restart'</code> parameter to the service resource.
+#    Defaults to undef i.e. whatever the service default is.
+#
 # === Examples
 #
 #  class { 'haproxy':
@@ -66,7 +71,8 @@ class haproxy (
   $enable           = true,
   $global_options   = $haproxy::params::global_options,
   $defaults_options = $haproxy::params::defaults_options,
-  $package_name     = 'haproxy'
+  $package_name     = 'haproxy',
+  $restart_command  = undef
 ) inherits haproxy::params {
   include concat::setup
 
@@ -148,6 +154,7 @@ class haproxy (
       hasrestart => true,
       hasstatus  => true,
       require    => $deps,
+      restart    => $restart_command,
     }
   }
 }

--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -103,6 +103,22 @@ describe 'haproxy', :type => :class do
             subject.should_not contain_service('haproxy')
           end
         end
+        context "on #{osfamily} when specifying a restart_command" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'restart_command' => '/etc/init.d/haproxy reload',
+              'manage_service'  => true,
+            }
+          end
+          it 'should set the haproxy package' do
+            subject.should contain_service('haproxy').with(
+              'restart' => '/etc/init.d/haproxy reload'
+            )
+          end
+        end
       end
     end
     describe 'for OS-specific configuration' do


### PR DESCRIPTION
This allows, for example, on CentOS/Debian/Ubuntu us to use /etc/init.d/haproxy reload to restart haproxy when config changes, which:
- includes syntax checks
- restarts without interruption to service

Without this it's easy to push out a option with, say a typo in it, which will cause haproxy to be left in a stopped state with broken config, because /etc/init.d/haproxy restart stops haproxy then starts it.

An alternative way to achieve this would be some logic to set an appropriate restart command for each distro, but I shied away from this, because it would presumably have to take into account things like Fedora's move to systemd.
