### PR TITLE
Add bind_options as parameter to allow additional values

### DIFF
--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -25,6 +25,10 @@
 #    The ip address the proxy binds to. Empty addresses, '*', and '0.0.0.0'
 #     mean that the proxy listens to all valid addresses on the system.
 #
+# [*bind_options*]
+#    Additional option for the bind parameter, values can be 'accept-proxy'.
+#    By default undef.
+#
 # [*mode*]
 #    The mode of operation for the frontend service. Valid values are undef,
 #    'tcp', 'http', and 'health'.
@@ -38,9 +42,10 @@
 #  Exporting the resource for a balancer member:
 #
 #  haproxy::frontend { 'puppet00':
-#    ipaddress => $::ipaddress,
-#    ports     => '18140',
-#    mode      => 'tcp',
+#    ipaddress    => $::ipaddress,
+#    ports        => '18140',
+#    mode         => 'tcp',
+#    bind_options => 'accept-proxy',
 #    options   => {
 #      'option'  => [
 #        'tcplog',
@@ -59,6 +64,7 @@ define haproxy::frontend (
   $ports,
   $ipaddress        = [$::ipaddress],
   $mode             = undef,
+  $bind_options     = undef,
   $collect_exported = true,
   $options          = {
     'option'  => [

--- a/templates/haproxy_frontend_block.erb
+++ b/templates/haproxy_frontend_block.erb
@@ -1,7 +1,7 @@
 
 frontend <%= @name %>
 <% Array(@ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port| -%>
-  bind <%= virtual_ip %>:<%= port %>
+  bind <%= virtual_ip %>:<%= port %> <%= bind_options %>
 <% end end -%>
 <% if @mode -%>
   mode  <%= @mode %>


### PR DESCRIPTION
Newer version of haproxy can use of additional option inside of the line `bind` parameter. This MR allows to add such kind of option on the same line. 
