### PR TITLE
Moved from `#include_class` to `#contain_class`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -17,7 +17,7 @@ describe 'haproxy', :type => :class do
           let(:params) do
             {'enable' => true}
           end
-          it { should include_class('concat::setup') }
+          it { should contain_class('concat::setup') }
           it 'should install the haproxy package' do
             subject.should contain_package('haproxy').with(
               'ensure' => 'present'
@@ -93,7 +93,7 @@ describe 'haproxy', :type => :class do
               'manage_service' => false,
             }
           end
-          it { should include_class('concat::setup') }
+          it { should contain_class('concat::setup') }
           it 'should install the haproxy package' do
             subject.should contain_package('haproxy').with(
               'ensure' => 'present'


### PR DESCRIPTION
Removed per the DEPRECATION warning [1].  Since this repo does not include a
Gemfile.lock, and the Gemfile does not have version requirements, `bundle`
will install the most recent upstream version of the gems.

I personally suggest adding the Gemfile.lock to the repo.  This will guarantee
the exact gem deps are installed on each execution of `bundle`.  However, for
now will keep things as is, and simply added a .gitignore.

```
[1] DEPRECATION: include_class is deprecated. Use contain_class instead. Called from /Users/jodewey/.rvm/gems/ruby-1.9.3-
p484/gems/rspec-puppet-1.0.1/lib/rspec-puppet/matchers/include_class.rb:7:in `block (2 levels) in <module:ManifestMatchers>'.
```
