### PR TITLE
Standardized module docs

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -16,20 +16,19 @@
 # === Parameters
 #
 # [*name*]
-#    The namevar of the defined resource type is the backend service's name.
-#     This name goes right after the 'backend' statement in haproxy.cfg
+#   The namevar of the defined resource type is the backend service's name.
+#    This name goes right after the 'backend' statement in haproxy.cfg
 #
 # [*options*]
-#    A hash of options that are inserted into the backend configuration block.
+#   A hash of options that are inserted into the backend configuration block.
 #
 # [*collect_exported*]
-#    Boolean, default 'true'. True means 'collect exported @@balancermember
-#     resources' (for the case when every balancermember node exports itself),
-#     false means 'rely on the existing declared balancermember resources' (for
-#     the case when you know the full set of balancermember in advance and use
-#     haproxy::balancermember with array arguments, which allows you to deploy
-#     everything in 1 run)
-#
+#   Boolean, default 'true'. True means 'collect exported @@balancermember
+#    resources' (for the case when every balancermember node exports itself),
+#    false means 'rely on the existing declared balancermember resources' (for
+#    the case when you know the full set of balancermember in advance and use
+#    haproxy::balancermember with array arguments, which allows you to deploy
+#    everything in 1 run)
 #
 # === Examples
 #

--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -21,39 +21,39 @@
 #    fragment name.
 #
 # [*listening_service*]
-#    The haproxy service's instance name (or, the title of the
-#     haproxy::listen resource). This must match up with a declared
-#     haproxy::listen resource.
+#   The haproxy service's instance name (or, the title of the
+#    haproxy::listen resource). This must match up with a declared
+#    haproxy::listen resource.
 #
 # [*ports*]
-#     An array or commas-separated list of ports for which the balancer member
-#     will accept connections from the load balancer. Note that cookie values
-#     aren't yet supported, but shouldn't be difficult to add to the
-#     configuration. If you use an array in server_names and ipaddresses, the
-#     same port is used for all balancermembers.
+#   An array or commas-separated list of ports for which the balancer member
+#    will accept connections from the load balancer. Note that cookie values
+#    aren't yet supported, but shouldn't be difficult to add to the
+#    configuration. If you use an array in server_names and ipaddresses, the
+#    same port is used for all balancermembers.
 #
 # [*server_names*]
-#     The name of the balancer member server as known to haproxy in the
-#      listening service's configuration block. This defaults to the
-#      hostname. Can be an array of the same length as ipaddresses,
-#      in which case a balancermember is created for each pair of
-#      server_names and ipaddresses (in lockstep).
+#   The name of the balancer member server as known to haproxy in the
+#    listening service's configuration block. This defaults to the
+#    hostname. Can be an array of the same length as ipaddresses,
+#    in which case a balancermember is created for each pair of
+#    server_names and ipaddresses (in lockstep).
 #
 # [*ipaddresses*]
-#      The ip address used to contact the balancer member server.
-#      Can be an array, see documentation to server_names.
+#   The ip address used to contact the balancer member server.
+#    Can be an array, see documentation to server_names.
 #
 # [*ensure*]
-#      If the balancermember should be present or absent.
-#      Defaults to present.
+#   If the balancermember should be present or absent.
+#    Defaults to present.
 #
 # [*options*]
-#      An array of options to be specified after the server declaration
-#       in the listening service's configuration block.
+#   An array of options to be specified after the server declaration
+#    in the listening service's configuration block.
 #
 # [*define_cookies*]
-#      If true, then add "cookie SERVERID" stickiness options.
-#      Default false.
+#   If true, then add "cookie SERVERID" stickiness options.
+#    Default false.
 #
 # === Examples
 #
@@ -95,6 +95,7 @@ define haproxy::balancermember (
   $options      = '',
   $define_cookies = false
 ) {
+
   # Template uses $ipaddresses, $server_name, $ports, $option
   concat::fragment { "${listening_service}_balancermember_${name}":
     order   => "20-${listening_service}-01-${name}",

--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -12,26 +12,26 @@
 # === Parameters
 #
 # [*name*]
-#    The namevar of the defined resource type is the frontend service's name.
-#     This name goes right after the 'frontend' statement in haproxy.cfg
+#   The namevar of the defined resource type is the frontend service's name.
+#    This name goes right after the 'frontend' statement in haproxy.cfg
 #
 # [*ports*]
-#    Ports on which the proxy will listen for connections on the ip address
+#   Ports on which the proxy will listen for connections on the ip address
 #    specified in the ipaddress parameter. Accepts either a single
 #    comma-separated string or an array of strings which may be ports or
 #    hyphenated port ranges.
 #
 # [*ipaddress*]
-#    The ip address the proxy binds to. Empty addresses, '*', and '0.0.0.0'
-#     mean that the proxy listens to all valid addresses on the system.
+#   The ip address the proxy binds to. Empty addresses, '*', and '0.0.0.0'
+#    mean that the proxy listens to all valid addresses on the system.
 #
 # [*mode*]
-#    The mode of operation for the frontend service. Valid values are undef,
+#   The mode of operation for the frontend service. Valid values are undef,
 #    'tcp', 'http', and 'health'.
 #
 # [*options*]
-#    A hash of options that are inserted into the frontend service
-#     configuration block.
+#   A hash of options that are inserted into the frontend service
+#    configuration block.
 #
 # === Examples
 #
@@ -66,11 +66,11 @@ define haproxy::frontend (
     ],
   }
 ) {
+
   # Template uses: $name, $ipaddress, $ports, $options
   concat::fragment { "${name}_frontend_block":
     order   => "15-${name}-00",
     target  => '/etc/haproxy/haproxy.cfg',
     content => template('haproxy/haproxy_frontend_block.erb'),
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@
 #
 # [*enable*]
 #   Chooses whether haproxy should be installed or ensured absent.
-#   Currently ONLY accepts valid boolean true/false values.
+#    Currently ONLY accepts valid boolean true/false values.
 #
 # [*global_options*]
 #   A hash of all the haproxy global options. If you want to specify more

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -17,34 +17,33 @@
 # === Parameters
 #
 # [*name*]
-#    The namevar of the defined resource type is the listening service's name.
-#     This name goes right after the 'listen' statement in haproxy.cfg
+#   The namevar of the defined resource type is the listening service's name.
+#    This name goes right after the 'listen' statement in haproxy.cfg
 #
 # [*ports*]
-#    Ports on which the proxy will listen for connections on the ip address
+#   Ports on which the proxy will listen for connections on the ip address
 #    specified in the ipaddress parameter. Accepts either a single
 #    comma-separated string or an array of strings which may be ports or
 #    hyphenated port ranges.
 #
 # [*ipaddress*]
-#    The ip address the proxy binds to. Empty addresses, '*', and '0.0.0.0'
-#     mean that the proxy listens to all valid addresses on the system.
+#   The ip address the proxy binds to. Empty addresses, '*', and '0.0.0.0'
+#    mean that the proxy listens to all valid addresses on the system.
 #
 # [*mode*]
-#    The mode of operation for the listening service. Valid values are undef,
+#   The mode of operation for the listening service. Valid values are undef,
 #    'tcp', 'http', and 'health'.
 #
 # [*options*]
-#    A hash of options that are inserted into the listening service
-#     configuration block.
+#   A hash of options that are inserted into the listening service
+#    configuration block.
 #
 # [*collect_exported*]
-#    Boolean, default 'true'. True means 'collect exported @@balancermember resources'
+#   Boolean, default 'true'. True means 'collect exported @@balancermember resources'
 #    (for the case when every balancermember node exports itself), false means
 #    'rely on the existing declared balancermember resources' (for the case when you 
 #    know the full set of balancermembers in advance and use haproxy::balancermember 
 #    with array arguments, which allows you to deploy everything in 1 run)
-#
 #
 # === Examples
 #
@@ -80,6 +79,7 @@ define haproxy::listen (
     'balance' => 'roundrobin'
   }
 ) {
+
   # Template uses: $name, $ipaddress, $ports, $options
   concat::fragment { "${name}_listen_block":
     order   => "20-${name}-00",


### PR DESCRIPTION
I am working on an haproxy SSL patch, and in the process found
the docs in the modules adhered to different spacing rules. This
patch simply standardizes all of the modules.
