### PR TITLE
Fix ordering of options changing

### DIFF
--- a/templates/haproxy_balancermember.erb
+++ b/templates/haproxy_balancermember.erb
@@ -1,3 +1,3 @@
 <% Array(@ipaddresses).zip(Array(@server_names)).each do |ipaddress,host| -%>
-  server <%= host %> <%= ipaddress %>:<%= Array(@ports).collect {|x|x.split(',')}.flatten.join(",#{ipaddress}:") %> <%= if @define_cookies then "cookie " + host end %> <%= Array(@options).join(" ") %>
+  server <%= host %> <%= ipaddress %>:<%= Array(@ports).collect {|x|x.split(',')}.flatten.join(",#{ipaddress}:") %> <%= if @define_cookies then "cookie " + host end %> <%= Array(@options).sort.join(" ") %>
 <% end -%>


### PR DESCRIPTION
The order of the options kept changing on each puppet run for me. Adding the sort makes the order consistent on each puppet run.
