### PR TITLE
Allow the fact to manage but disable the haproxy service

### DIFF
--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -15,7 +15,8 @@ describe 'haproxy', :type => :class do
             { :osfamily => osfamily }.merge default_facts
           end
           let(:params) do
-            {'enable' => true}
+            {'enable'         => true,
+             'manage_service' => true}
           end
           it { should contain_class('concat::setup') }
           it 'should install the haproxy package' do
@@ -100,7 +101,63 @@ describe 'haproxy', :type => :class do
             )
           end
           it 'should not manage the haproxy service' do
-            subject.should_not contain_service('haproxy')
+            subject.should contain_service('haproxy').with(
+              'ensure'     => 'stopped',
+              'enable'     => 'false',
+              'hasrestart' => 'true',
+              'hasstatus'  => 'true',
+              'require'    => [
+                'Concat[/etc/haproxy/haproxy.cfg]',
+                'File[/var/lib/haproxy]'
+              ]
+            )
+          end
+          it 'should set up /etc/haproxy/haproxy.cfg as a concat resource' do
+            subject.should contain_concat('/etc/haproxy/haproxy.cfg').with(
+              'owner' => '0',
+              'group' => '0',
+              'mode'  => '0644'
+            )
+          end
+          it 'should manage the chroot directory' do
+            subject.should contain_file('/var/lib/haproxy').with(
+              'ensure' => 'directory'
+            )
+          end
+          it 'should contain a header concat fragment' do
+            subject.should contain_concat__fragment('00-header').with(
+              'target'  => '/etc/haproxy/haproxy.cfg',
+              'order'   => '01',
+              'content' => "# This file managed by Puppet\n"
+            )
+          end
+          it 'should contain a haproxy-base concat fragment' do
+            subject.should contain_concat__fragment('haproxy-base').with(
+              'target'  => '/etc/haproxy/haproxy.cfg',
+              'order'   => '10'
+            )
+          end
+          describe 'Base concat fragment contents' do
+            let(:contents) { param_value(subject, 'concat::fragment', 'haproxy-base', 'content').split("\n") }
+            it 'should contain global and defaults sections' do
+              contents.should include('global')
+              contents.should include('defaults')
+            end
+            it 'should log to an ip address for local0' do
+              contents.should be_any { |match| match =~ /  log  \d+(\.\d+){3} local0/ }
+            end
+            it 'should specify the default chroot' do
+              contents.should include('  chroot  /var/lib/haproxy')
+            end
+            it 'should specify the correct user' do
+              contents.should include('  user  haproxy')
+            end
+            it 'should specify the correct group' do
+              contents.should include('  group  haproxy')
+            end
+            it 'should specify the correct pidfile' do
+              contents.should include('  pidfile  /var/run/haproxy.pid')
+            end
           end
         end
         context "on #{osfamily} when specifying a restart_command" do


### PR DESCRIPTION
In an active/passive scenario, as a user I'd like the
configuration to be set and the package to be installed
without the service being started.

The `if $enable` (l81) prevents this. Today, if one sets
`manage_service = true` and `enable = false`, it will result
in a catalog compilation issue, due to the `Concat[/etc/haproxy/haproxy.cfg']`
dependency on line 134 not being met.
