### PR TITLE
Set User & Group from options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,6 +118,8 @@ class haproxy (
     if $global_options['chroot'] {
       file { $global_options['chroot']:
         ensure => directory,
+        owner  => $global_options['user'],
+        group  => $global_options['group'],
       }
     }
 


### PR DESCRIPTION
Prior to this commit we managed the file but did not
set the ownership to the global options hash content.
Thus if you want to run this process as another user
you have to use collector override to make this work
as the module is managing the file but not pulling
the owner and group

I need to update the specs, just creating this so I remember to do so
