### PR TITLE
Pin Rake to ~> 10.1 to support Ruby 1.8.7

### DIFF
--- a/.gemfile
+++ b/.gemfile
@@ -1,5 +1,0 @@
-source :rubygems
-
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
-gem 'puppet', puppetversion
-gem 'puppetlabs_spec_helper', '>= 0.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'rake',                    :require => false
+  gem 'rake', '~> 10.1.0',       :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'rspec-system',            :require => false


### PR DESCRIPTION
The latest Rake update requires Ruby >= 1.9. This update
fixes the failing 1.8.7 tests by pinning Rake to the last
supported version on ruby 1.8.7.
