### PR TITLE
Remove redundant params section

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,62 +6,8 @@
 #
 class haproxy::params {
   case $osfamily {
-    Redhat: {
+    'Archlinux', 'Debian', 'Redhat': {
       $global_options   = {
-        'log'     => "${::ipaddress} local0",
-        'chroot'  => '/var/lib/haproxy',
-        'pidfile' => '/var/run/haproxy.pid',
-        'maxconn' => '4000',
-        'user'    => 'haproxy',
-        'group'   => 'haproxy',
-        'daemon'  => '',
-        'stats'   => 'socket /var/lib/haproxy/stats'
-      }
-      $defaults_options = {
-        'log'     => 'global',
-        'stats'   => 'enable',
-        'option'  => 'redispatch',
-        'retries' => '3',
-        'timeout' => [
-          'http-request 10s',
-          'queue 1m',
-          'connect 10s',
-          'client 1m',
-          'server 1m',
-          'check 10s',
-        ],
-        'maxconn' => '8000'
-      }
-    }
-    Debian: {
-      $global_options   = {
-        'log'     => "${::ipaddress} local0",
-        'chroot'  => '/var/lib/haproxy',
-        'pidfile' => '/var/run/haproxy.pid',
-        'maxconn' => '4000',
-        'user'    => 'haproxy',
-        'group'   => 'haproxy',
-        'daemon'  => '',
-        'stats'   => 'socket /var/lib/haproxy/stats'
-      }
-      $defaults_options = {
-        'log'     => 'global',
-        'stats'   => 'enable',
-        'option'  => 'redispatch',
-        'retries' => '3',
-        'timeout' => [
-          'http-request 10s',
-          'queue 1m',
-          'connect 10s',
-          'client 1m',
-          'server 1m',
-          'check 10s',
-        ],
-        'maxconn' => '8000'
-      }
-    }
-    Archlinux: {
-      $global_options  = {
         'log'     => "${::ipaddress} local0",
         'chroot'  => '/var/lib/haproxy',
         'pidfile' => '/var/run/haproxy.pid',


### PR DESCRIPTION
The parameters for 'Redhat', 'Debian' and 'Archilinux were identical
and have been merged.
