### PR TITLE
Remove warnings when storeconfigs is not being used

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -68,7 +68,7 @@ define haproxy::backend (
   }
 
   if $collect_exported {
-    Haproxy::Balancermember <<| listening_service == $name |>>
+    haproxy::balancermember::collect_exported { $name: }
   }
   # else: the resources have been created and they introduced their
   # concat fragments. We don't have to do anything about them.

--- a/manifests/balancermember/collect_exported.pp
+++ b/manifests/balancermember/collect_exported.pp
@@ -1,0 +1,15 @@
+# == Define: haproxy::balancermember::collect_exported
+#
+# Defined type used to collect haproxy::balancermember exported resource
+#
+# === Parameters
+#
+# None
+#
+# === Examples
+#
+# haproxy::balancermember::collect_exported { 'SomeService': }
+#
+define haproxy::balancermember::collect_exported {
+    Haproxy::Balancermember <<| listening_service == $name |>>
+}

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -88,7 +88,7 @@ define haproxy::listen (
   }
 
   if $collect_exported {
-    Haproxy::Balancermember <<| listening_service == $name |>>
+    haproxy::balancermember::collect_exported { $name: }
   }
   # else: the resources have been created and they introduced their
   # concat fragments. We don't have to do anything about them.


### PR DESCRIPTION
Added a defined type to collect exported resources, this is to prevent
parser warnings when storeconfigs is not being used (i.e when using
simple puppet apply with no PuppetDB)
