### PR TITLE
Enable undef to service_ensure for better cluster management

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,8 +87,8 @@ class haproxy (
   include concat::setup
 
   if $service_ensure != true and $service_ensure != false {
-    if ! ($service_ensure in [ 'running','stopped']) {
-      fail('service_ensure parameter must be running, stopped, true, or false')
+    if ! ($service_ensure in [ 'running','stopped','undef']) {
+      fail('service_ensure parameter must be running, stopped, true, false or undef')
     }
   }
   validate_string($package_name,$package_ensure)
@@ -106,7 +106,11 @@ class haproxy (
     }
   } else {
     $_package_ensure = $package_ensure
-    $_service_ensure = $service_ensure
+    if $service_ensure == 'undef' {
+      $_service_ensure = undef
+    } else {
+      $_service_ensure = $service_ensure
+    }
   }
 
   # To support deprecating $manage_service

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,6 +17,7 @@ class haproxy::service inherits haproxy {
       enable     => $_service_ensure ? {
         'running' => true,
         'stopped' => false,
+        'undef'   => undef,
         default   => $_service_ensure,
       },
       name       => 'haproxy',


### PR DESCRIPTION
In cluster environments, where haproxy is managed by corosync, is very needed that module doesn't enforce service by ensure. Added 'undef' state, that enables this and keeps the service notifying when config files changed. I would like to do this better, but seems there is no nice out of box solution, until service provider will accept 'undef' string such discussed at https://projects.puppetlabs.com/issues/22587#note-2 .
