### PR TITLE
Add custom_fragment parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,13 @@
 #    Passed directly as the <code>'restart'</code> parameter to the service resource.
 #    Defaults to undef i.e. whatever the service default is.
 #
+#[*custom_fragment*]
+#  Allows arbitrary HAProxy configuration to be passed through to support
+#  additional configuration not available via parameters, or to short-circute
+#  the defined resources such as haproxy::listen when an operater would rather
+#  just write plain configuration. Accepts a string (ie, output from the
+#  template() function). Defaults to undef
+#
 # === Examples
 #
 #  class { 'haproxy':
@@ -79,6 +86,7 @@ class haproxy (
   $global_options   = $haproxy::params::global_options,
   $defaults_options = $haproxy::params::defaults_options,
   $restart_command  = undef,
+  $custom_fragment  = undef,
 
   # Deprecated
   $manage_service   = undef,

--- a/spec/acceptance/single_node/basic_spec.rb
+++ b/spec/acceptance/single_node/basic_spec.rb
@@ -4,10 +4,22 @@ if hosts.length == 1
   describe "running puppet" do
     it 'should be able to apply class haproxy' do
       pp = <<-EOS
-      class { 'haproxy': }
+      class { 'haproxy':
+        custom_fragment => "listen stats :9090
+          mode http
+          stats uri /
+          stats auth puppet:puppet",
+      }
       haproxy::listen { 'test00': ports => '80',}
       EOS
       apply_manifest(pp, :catch_failures => true)
+    end
+
+    it 'should have stats listening' do
+      shell("/usr/bin/curl -u puppet:puppet localhost:9090") do |r|
+        r.stdout.should =~ /HAProxy/
+        r.exit_code.should == 0
+      end
     end
   end
 end

--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -169,6 +169,19 @@ describe 'haproxy', :type => :class do
             )
           end
         end
+        context "on #{osfamily} when specifying custom content" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            { 'custom_fragment' => "listen stats :9090\n  mode http\n  stats uri /\n  stats auth puppet:puppet\n" }
+          end
+          it 'should set the haproxy package' do
+            subject.should contain_concat__fragment('haproxy-base').with_content(
+              /listen stats :9090\n  mode http\n  stats uri \/\n  stats auth puppet:puppet\n/
+            )
+          end
+        end
       end
     end
     describe 'for OS-specific configuration' do

--- a/spec/defines/userlist_spec.rb
+++ b/spec/defines/userlist_spec.rb
@@ -20,7 +20,7 @@ describe 'haproxy::userlist' do
     end
 
     it { should contain_concat__fragment('admins_userlist_block').with(
-      'order'   => '10-admins-00',
+      'order'   => '12-admins-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nuserlist admins\n  group superadmins users kitchen scott\n  group megaadmins users kitchen\n  user scott insecure-password elgato\n  user kitchen insecure-password foobar\n"
     ) }

--- a/templates/haproxy-base.cfg.erb
+++ b/templates/haproxy-base.cfg.erb
@@ -19,3 +19,7 @@ defaults
   <%= key %>  <%= val %>
 <% end -%>
 <% end -%>
+<% if @custom_fragment -%>
+
+<%= @custom_fragment %>
+<% end -%>


### PR DESCRIPTION
The parameters are often limited in what they can express. this allows
custom templates to be used for the configuration
