### PR TITLE
Add custom fragment for haproxy::listen

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -30,6 +30,11 @@
 #    haproxy::balancermember with array arguments, which allows you to deploy
 #    everything in 1 run)
 #
+# [*custom_fragment*]
+#   Allows arbitrary HAProxy configuration to be passed through to support
+#   additional backend configuration not available via parameters. Accepts a
+#   string (ie, output from the template() function). Defaults to undef
+#
 # === Examples
 #
 #  Exporting the resource for a backend member:
@@ -57,7 +62,8 @@ define haproxy::backend (
       'ssl-hello-chk'
     ],
     'balance' => 'roundrobin'
-  }
+  },
+  $custom_fragment  = undef,
 ) {
 
   # Template uses: $name, $ipaddress, $ports, $options

--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -33,6 +33,11 @@
 #   A hash of options that are inserted into the frontend service
 #    configuration block.
 #
+# [*custom_fragment*]
+#   Allows arbitrary HAProxy configuration to be passed through to support
+#   additional frontend configuration not available via parameters. Accepts a
+#   string (ie, output from the template() function). Defaults to undef
+#
 # === Examples
 #
 #  Exporting the resource for a balancer member:
@@ -64,7 +69,8 @@ define haproxy::frontend (
     'option'  => [
       'tcplog',
     ],
-  }
+  },
+  $custom_fragment  = undef,
 ) {
 
   # Template uses: $name, $ipaddress, $ports, $options

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -49,6 +49,11 @@
 #    know the full set of balancermembers in advance and use haproxy::balancermember 
 #    with array arguments, which allows you to deploy everything in 1 run)
 #
+# [*custom_fragment*]
+#   Allows arbitrary HAProxy configuration to be passed through to support
+#   additional listen configuration not available via parameters. Accepts a
+#   string (ie, output from the template() function). Defaults to undef
+#
 # === Examples
 #
 #  Exporting the resource for a balancer member:
@@ -82,10 +87,11 @@ define haproxy::listen (
     ],
     'balance' => 'roundrobin'
   },
-  $bind_options     = ''
+  $bind_options     = '',
+  $custom_fragment  = undef,
 ) {
 
-  # Template uses: $name, $ipaddress, $ports, $options
+  # Template uses: $name, $ipaddress, $ports, $options, $custom_fragment
   concat::fragment { "${name}_listen_block":
     order   => "20-${name}-00",
     target  => '/etc/haproxy/haproxy.cfg',

--- a/spec/defines/backend_spec.rb
+++ b/spec/defines/backend_spec.rb
@@ -17,9 +17,21 @@ describe 'haproxy::backend' do
       'content' => "\nbackend bar\n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
     ) }
   end
+  context "when custom_fragment is provided" do
+    let(:params) do
+      {
+        :name            => 'servers',
+        :custom_fragment => '  server webserver 10.0.0.20:8000 check
+  server webserver 10.0.0.20:8001 check'
+      }
+    end
 
-
-
+    it { should contain_concat__fragment('servers_backend_block').with(
+      'order'   => '20-servers-00',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "\nbackend servers\n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n  server webserver 10.0.0.20:8000 check\n  server webserver 10.0.0.20:8001 check\n"
+    ) }
+  end
 end
 
 

--- a/spec/defines/frontend_spec.rb
+++ b/spec/defines/frontend_spec.rb
@@ -50,4 +50,21 @@ describe 'haproxy::frontend' do
       'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option  tcplog\n"
     ) }
   end
+
+  context "when custom_fragment is provided" do
+    let(:params) do
+      {
+        :name            => 'apache',
+        :ipaddress       => '23.23.23.23',
+        :ports           => '80',
+        :custom_fragment => '  bind 23.23.23.23:443 ssl crt /path/to/cert.crt'
+      }
+    end
+
+    it { should contain_concat__fragment('apache_frontend_block').with(
+      'order'   => '15-apache-00',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  option  tcplog\n  bind 23.23.23.23:443 ssl crt /path/to/cert.crt\n"
+    ) }
+  end
 end

--- a/spec/defines/listen_spec.rb
+++ b/spec/defines/listen_spec.rb
@@ -65,4 +65,20 @@ describe 'haproxy::listen' do
       'content' => "\nlisten apache\n  bind 1.1.1.1:80 the options go here\n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
     ) }
   end
+  context "when custom_fragment is provided" do
+    let(:params) do
+      {
+        :name            => 'apache',
+        :ipaddress       => '23.23.23.23',
+        :ports           => '80',
+        :custom_fragment => '  bind 23.23.23.23:443 ssl crt /path/to/cert.crt'
+      }
+    end
+
+    it { should contain_concat__fragment('apache_listen_block').with(
+      'order'   => '20-apache-00',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n  bind 23.23.23.23:443 ssl crt /path/to/cert.crt\n"
+    ) }
+  end
 end

--- a/templates/fragments/_custom.erb
+++ b/templates/fragments/_custom.erb
@@ -1,0 +1,3 @@
+<% if @custom_fragment -%>
+<%= @custom_fragment %>
+<% end -%>

--- a/templates/haproxy_backend_block.erb
+++ b/templates/haproxy_backend_block.erb
@@ -1,3 +1,4 @@
 
 backend <%= @name %>
 <%= scope.function_template(['haproxy/fragments/_options.erb']) -%>
+<%= scope.function_template(['haproxy/fragments/_custom.erb']) -%>

--- a/templates/haproxy_frontend_block.erb
+++ b/templates/haproxy_frontend_block.erb
@@ -3,3 +3,4 @@ frontend <%= @name %>
 <%= scope.function_template(['haproxy/fragments/_bind.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_mode.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_options.erb']) -%>
+<%= scope.function_template(['haproxy/fragments/_custom.erb']) -%>

--- a/templates/haproxy_listen_block.erb
+++ b/templates/haproxy_listen_block.erb
@@ -3,3 +3,4 @@ listen <%= @name %>
 <%= scope.function_template(['haproxy/fragments/_bind.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_mode.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_options.erb']) -%>
+<%= scope.function_template(['haproxy/fragments/_custom.erb']) -%>


### PR DESCRIPTION
The listen block should be flexible enough for various needs but not
overloaded by parameters. The custom_fragment parameter allows for
custom configuration.
