### PR TITLE
Reduce template code duplication

### DIFF
--- a/spec/defines/frontend_spec.rb
+++ b/spec/defines/frontend_spec.rb
@@ -14,7 +14,7 @@ describe 'haproxy::frontend' do
     it { should contain_concat__fragment('croy_frontend_block').with(
       'order'   => '15-croy-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend croy\n  bind 1.1.1.1:18140\n  option  tcplog\n"
+      'content' => "\nfrontend croy\n  bind 1.1.1.1:18140 \n  option  tcplog\n"
     ) }
   end
   context "when an array of ports is provided" do
@@ -32,7 +32,7 @@ describe 'haproxy::frontend' do
     it { should contain_concat__fragment('apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  bind 23.23.23.23:80\n  bind 23.23.23.23:443\n  option  tcplog\n"
+      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option  tcplog\n"
     ) }
   end
   context "when a comma-separated list of ports is provided" do
@@ -47,7 +47,7 @@ describe 'haproxy::frontend' do
     it { should contain_concat__fragment('apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  bind 23.23.23.23:80\n  bind 23.23.23.23:443\n  option  tcplog\n"
+      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option  tcplog\n"
     ) }
   end
 end

--- a/templates/fragments/_bind.erb
+++ b/templates/fragments/_bind.erb
@@ -1,0 +1,3 @@
+<% Array(@ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port| -%>
+  bind <%= virtual_ip %>:<%= port %> <%= Array(@bind_options).join(" ") %>
+<% end end -%>

--- a/templates/fragments/_mode.erb
+++ b/templates/fragments/_mode.erb
@@ -1,0 +1,3 @@
+<% if @mode -%>
+  mode  <%= @mode %>
+<% end -%>

--- a/templates/fragments/_options.erb
+++ b/templates/fragments/_options.erb
@@ -1,0 +1,5 @@
+<% @options.sort.each do |key, val| -%>
+<% Array(val).each do |item| -%>
+  <%= key %>  <%= item %>
+<% end -%>
+<% end -%>

--- a/templates/haproxy_backend_block.erb
+++ b/templates/haproxy_backend_block.erb
@@ -1,7 +1,3 @@
 
 backend <%= @name %>
-<% @options.sort.each do |key, val| -%>
-<% Array(val).each do |item| -%>
-  <%= key %>  <%= item %>
-<% end -%>
-<% end -%>
+<%= scope.function_template(['haproxy/fragments/_options.erb']) -%>

--- a/templates/haproxy_frontend_block.erb
+++ b/templates/haproxy_frontend_block.erb
@@ -1,13 +1,5 @@
 
 frontend <%= @name %>
-<% Array(@ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port| -%>
-  bind <%= virtual_ip %>:<%= port %>
-<% end end -%>
-<% if @mode -%>
-  mode  <%= @mode %>
-<% end -%>
-<% @options.sort.each do |key, val| -%>
-<% Array(val).each do |item| -%>
-  <%= key %>  <%= item %>
-<% end -%>
-<% end -%>
+<%= scope.function_template(['haproxy/fragments/_bind.erb']) -%>
+<%= scope.function_template(['haproxy/fragments/_mode.erb']) -%>
+<%= scope.function_template(['haproxy/fragments/_options.erb']) -%>

--- a/templates/haproxy_listen_block.erb
+++ b/templates/haproxy_listen_block.erb
@@ -1,13 +1,5 @@
 
 listen <%= @name %>
-<% Array(@ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port| -%>
-  bind <%= virtual_ip %>:<%= port %> <%= Array(@bind_options).join(" ") %>
-<% end end -%>
-<% if @mode -%>
-  mode  <%= @mode %>
-<% end -%>
-<% @options.sort.each do |key, val| -%>
-<% Array(val).each do |item| -%>
-  <%= key %>  <%= item %>
-<% end -%>
-<% end -%>
+<%= scope.function_template(['haproxy/fragments/_bind.erb']) -%>
+<%= scope.function_template(['haproxy/fragments/_mode.erb']) -%>
+<%= scope.function_template(['haproxy/fragments/_options.erb']) -%>


### PR DESCRIPTION
The listen template is essentially just a combination of frontend/backends in haproxy, and lots of code was duplicated between the three templates. This commit moves the stanzas into fragments.
