### PR TITLE
Avoid mixing up backend servers

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -60,6 +60,10 @@ define haproxy::backend (
   }
 ) {
 
+  if defined(Haproxy::Listen[$name]) {
+    fail("An haproxy::listen resource was discovered with the same name (${name}) which is not supported")
+  }
+
   # Template uses: $name, $ipaddress, $ports, $options
   concat::fragment { "${name}_backend_block":
     order   => "20-${name}-00",

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -85,6 +85,10 @@ define haproxy::listen (
   $bind_options     = ''
 ) {
 
+  if defined(Haproxy::Backend[$name]) {
+    fail("An haproxy::backend resource was discovered with the same name (${name}) which is not supported")
+  }
+
   # Template uses: $name, $ipaddress, $ports, $options
   concat::fragment { "${name}_listen_block":
     order   => "20-${name}-00",


### PR DESCRIPTION
If an haproxy::listen and haproxy::backend have the same name, their
order will be `20-<name>-00` and concat ordering will be mixed up. The
haproxy::balancermember resource uses this ordering to add backend
servers to a listen/backend block (with the order `20-<name>-01`) and
this is the least-impactful way to avoid balancer members from being
cross-associated without introducing backwards-incompatible changes.
