### PR TITLE
Define each server/port combination on its own line

### DIFF
--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -22,7 +22,7 @@ describe 'haproxy::balancermember' do
     it { should contain_concat__fragment('croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "  server dero 1.1.1.1:18140  check\n"
+      'content' => "  server dero 1.1.1.1:18140 check\n"
     ) }
   end
 
@@ -40,7 +40,7 @@ describe 'haproxy::balancermember' do
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'ensure'  => 'absent',
-      'content' => "  server dero 1.1.1.1:18140  \n"
+      'content' => "  server dero 1.1.1.1:18140 \n"
     ) }
   end
 
@@ -57,7 +57,7 @@ describe 'haproxy::balancermember' do
     it { should contain_concat__fragment('croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "  server dero 1.1.1.1:18140  check close\n"
+      'content' => "  server dero 1.1.1.1:18140 check close\n"
     ) }
   end
 
@@ -93,7 +93,7 @@ describe 'haproxy::balancermember' do
     it { should contain_concat__fragment('croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "  server server01 192.168.56.200:18140  check\n  server server02 192.168.56.201:18140  check\n"
+      'content' => "  server server01 192.168.56.200:18140 check\n  server server02 192.168.56.201:18140 check\n"
     ) }
   end
   context 'with multiple servers and multiple ports' do
@@ -111,7 +111,7 @@ describe 'haproxy::balancermember' do
     it { should contain_concat__fragment('croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "  server server01 192.168.56.200:18140,192.168.56.200:18150  check\n  server server02 192.168.56.201:18140,192.168.56.201:18150  check\n"
+      'content' => "  server server01 192.168.56.200:18140 check\n  server server01 192.168.56.200:18150 check\n  server server02 192.168.56.201:18140 check\n  server server02 192.168.56.201:18150 check\n"
     ) }
   end
 end

--- a/templates/haproxy_balancermember.erb
+++ b/templates/haproxy_balancermember.erb
@@ -1,3 +1,5 @@
 <% Array(@ipaddresses).zip(Array(@server_names)).each do |ipaddress,host| -%>
-  server <%= host %> <%= ipaddress %>:<%= Array(@ports).collect {|x|x.split(',')}.flatten.join(",#{ipaddress}:") %> <%= if @define_cookies then "cookie " + host end %> <%= Array(@options).sort.join(" ") %>
+  <%- Array(@ports).each do |port| -%>
+  server <%= host %> <%= ipaddress %>:<%= port %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %>
+  <%- end -%>
 <% end -%>


### PR DESCRIPTION
When referencing
http://cbonte.github.io/haproxy-dconv/configuration-1.4.html#5 and
http://cbonte.github.io/haproxy-dconv/configuration-1.4.html#server it
does not appear that having multiple address/port combinations on one
line is officially supported, and indeed the "check" option only applies
to the first port, not later ones.

This commit breaks each server into its own line.

Closes #74
