### PR TITLE
Add bind_options for frontends

### DIFF
--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -29,6 +29,10 @@
 #   The mode of operation for the frontend service. Valid values are undef,
 #    'tcp', 'http', and 'health'.
 #
+# [*bind_options*]
+#   An array of options to be specified after the bind declaration in the
+#    bind's configuration block.
+#
 # [*options*]
 #   A hash of options that are inserted into the frontend service
 #    configuration block.
@@ -38,11 +42,12 @@
 #  Exporting the resource for a balancer member:
 #
 #  haproxy::frontend { 'puppet00':
-#    ipaddress => $::ipaddress,
-#    ports     => '18140',
-#    mode      => 'tcp',
-#    options   => {
-#      'option'  => [
+#    ipaddress    => $::ipaddress,
+#    ports        => '18140',
+#    mode         => 'tcp',
+#    bind_options => 'accept-proxy',
+#    options      => {
+#      'option'   => [
 #        'tcplog',
 #        'accept-invalid-http-request',
 #      ],
@@ -59,6 +64,7 @@ define haproxy::frontend (
   $ports,
   $ipaddress        = [$::ipaddress],
   $mode             = undef,
+  $bind_options     = undef,
   $collect_exported = true,
   $options          = {
     'option'  => [

--- a/spec/defines/frontend_spec.rb
+++ b/spec/defines/frontend_spec.rb
@@ -35,6 +35,21 @@ describe 'haproxy::frontend' do
       'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option  tcplog\n"
     ) }
   end
+  context "when bind options are provided" do
+    let(:params) do
+      {
+        :name         => 'apache',
+        :ports        => ['80','8080'],
+        :bind_options => [ 'the options', 'go here' ]
+      }
+    end
+
+    it { should contain_concat__fragment('apache_frontend_block').with(
+      'order'   => '15-apache-00',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "\nfrontend apache\n  bind 1.1.1.1:80 the options go here\n  bind 1.1.1.1:8080 the options go here\n  option  tcplog\n"
+    ) }
+  end
   context "when a comma-separated list of ports is provided" do
     let(:params) do
       {


### PR DESCRIPTION
Bind options are available for listen resources, but not for frontend
services, but they should be.

Closes #64
