### PR TITLE
Fix puppet-lint tests

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -75,7 +75,7 @@
 #  Creating the resource for multiple balancer members at once
 #  (for single-pass installation of haproxy without requiring a first
 #  pass to export the resources if you know the members in advance):
-# 
+#
 #  haproxy::balancermember { 'haproxy':
 #    listening_service => 'puppet00',
 #    ports             => '8140',
@@ -83,7 +83,7 @@
 #    ipaddresses       => ['192.168.56.200', '192.168.56.201'],
 #    options           => 'check',
 #  }
-#  
+#
 #  (this resource can be declared anywhere)
 #
 define haproxy::balancermember (

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -45,8 +45,8 @@
 # [*collect_exported*]
 #   Boolean, default 'true'. True means 'collect exported @@balancermember resources'
 #    (for the case when every balancermember node exports itself), false means
-#    'rely on the existing declared balancermember resources' (for the case when you 
-#    know the full set of balancermembers in advance and use haproxy::balancermember 
+#    'rely on the existing declared balancermember resources' (for the case when you
+#    know the full set of balancermembers in advance and use haproxy::balancermember
 #    with array arguments, which allows you to deploy everything in 1 run)
 #
 # === Examples

--- a/manifests/userlist.pp
+++ b/manifests/userlist.pp
@@ -1,7 +1,7 @@
 # == Define Resource Type: haproxy::userlist
 #
 # This type will set up a userlist configuration block inside the haproxy.cfg
-#  file on an haproxy load balancer. 
+#  file on an haproxy load balancer.
 #
 # See http://cbonte.github.io/haproxy-dconv/configuration-1.4.html#3.4 for more info
 #


### PR DESCRIPTION
Remove trailing white-space so puppet lint doesn't return errors anymore.
