### PR TITLE
Allow greater flexibility in listen directive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ##Overview
 
-The haproxy module provides the ability to install, configure, and manage HAProxy. 
+The haproxy module provides the ability to install, configure, and manage HAProxy.
 
 ##Module Description
 
@@ -121,6 +121,28 @@ haproxy::listen { 'puppet00':
   },
 }
 ```
+###Configuring multi-network daemon listener
+
+One might have more advanced needs for the listen block, then use the `$bind` parameter:
+
+```puppet
+haproxy::listen { 'puppet00':
+  mode    => 'tcp',
+  options => {
+    'option'  => [
+      'tcplog',
+      'ssl-hello-chk',
+    ],
+    'balance' => 'roundrobin',
+  },
+  bind    => {
+    '10.0.0.1:443'      => ['ssl', 'crt', 'puppetlabs.com'],
+    '168.12.12.12:80'   => [],
+    '192.168.122.42:80' => []
+  },
+}
+```
+Note: `$ports` or `$ipaddress` and `$bind` are mutually exclusive
 
 ###Configuring HAProxy load-balanced member nodes
 
@@ -285,7 +307,10 @@ This type sets up a frontend service configuration block in haproxy.cfg. The HAP
 **Parameters**
 
 #####`bind_options`
-Lists an array of options to be specified after the bind declaration in the bind's configuration block.
+Lists an array of options to be specified after the bind declaration in the bind's configuration block. **Deprecated**: This parameter is being deprecated in favor of $bind
+
+#####`bind`
+A hash of ipaddress:port, with the haproxy bind options the address will have in the listening service's configuration block.
 
 #####`ipaddress`
 Specifies the IP address the proxy binds to. No value, '\*', and '0.0.0.0' mean that the proxy listens to all valid addresses on the system.
@@ -333,7 +358,10 @@ Using storeconfigs, you can export the `haproxy::balancermember` resources on al
 **Parameters:**
 
 #####`bind_options`
-Sets the options to be specified after the bind declaration in the listening service's configuration block. Displays as an array. 
+Sets the options to be specified after the bind declaration in the listening service's configuration block. Displays as an array. **Deprecated**: This parameter is being deprecated in favor of $bind
+
+#####`bind`
+A hash of ipaddress:port, with the haproxy bind options the address will have in the listening service's configuration block.
 
 #####`collect_exported`
 Enables exported resources from `haproxy::balancermember` to be collected, serving as a form of autodiscovery. Displays as a Boolean and defaults to 'true'. 

--- a/spec/defines/frontend_spec.rb
+++ b/spec/defines/frontend_spec.rb
@@ -111,6 +111,19 @@ describe 'haproxy::frontend' do
     end
   end
   # C9949
+  context "when a ports parameter and a bind parameter are passed" do
+    let(:params) do
+      {
+        :name  => 'apache',
+        :bind  => {'192.168.0.1:80' => ['ssl']},
+        :ports => '80'
+      }
+    end
+
+    it 'should raise error' do
+      expect { subject }.to raise_error Puppet::Error, /mutually exclusive/
+    end
+  end
   context "when multiple IPs are provided" do
     let(:params) do
       {

--- a/spec/defines/listen_spec.rb
+++ b/spec/defines/listen_spec.rb
@@ -127,6 +127,34 @@ describe 'haproxy::listen' do
       'content' => "\nlisten apache\n  bind *:80 \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
     ) }
   end
+  context "when a bind parameter hash is passed" do
+    let(:params) do
+      {
+        :name      => 'apache',
+        :ipaddress => '',
+        :bind      => {'10.0.0.1:333' => ['ssl', 'crt', 'public.puppetlabs.com'], '192.168.122.1:8082' => []},
+      }
+    end
+
+    it { should contain_concat__fragment('apache_listen_block').with(
+      'order'   => '20-apache-00',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "\nlisten apache\n  bind 10.0.0.1:333 ssl crt public.puppetlabs.com\n  bind 192.168.122.1:8082 \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+    ) }
+  end
+  context "when a ports parameter and a bind parameter are passed" do
+    let(:params) do
+      {
+        :name  => 'apache',
+        :bind  => {'192.168.0.1:80' => ['ssl']},
+        :ports => '80'
+      }
+    end
+
+    it 'should raise error' do
+      expect { subject }.to raise_error Puppet::Error, /mutually exclusive/
+    end
+  end
   # C9977
   context "when an invalid hostname is passed" do
     let(:params) do

--- a/templates/fragments/_bind.erb
+++ b/templates/fragments/_bind.erb
@@ -1,16 +1,34 @@
 <% require 'ipaddr' -%>
-<% Array(@ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port| -%>
-  <%-
-    begin
-      IPAddr.new(virtual_ip)
-      valid_ip = true
-    rescue ArgumentError => e
-      valid_ip = false
-    end
-    if ! valid_ip and ! virtual_ip.match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and virtual_ip != "*"
-      scope.function_fail(["Invalid IP address or hostname [#{virtual_ip}]"])
-    end
-  -%>
-  <%- scope.function_fail(["Port [#{port}] is outside of range 1-65535"]) if port.to_i < 1 or port.to_i > 65535 -%>
-  bind <%= virtual_ip %>:<%= port %> <%= Array(@bind_options).join(" ") %>
-<% end end -%>
+<% if @bind
+  @bind.keys.uniq.sort.each do |virtual_ip|
+  if ip_port = virtual_ip.match(/^([A-Za-z0-9\.-]+):([0-9]+)$/)
+    ip = ip_port[1]
+    port = ip_port[2]
+  elsif virtual_ip.match(/^([A-Za-z0-9\.-]+)$/)
+   ip = virtual_ip
+  end
+  begin
+    IPAddr.new(ip)
+    valid_ip = true
+  rescue ArgumentError => e
+    valid_ip = false
+  end
+  if ! valid_ip and ! ip.match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and ip != "*"
+    scope.function_fail(["Invalid IP address or hostname [#{ip}]"])
+  end
+  scope.function_fail(["Port #{port} for IP #{ip} is outside of range 1-65535"]) if port and (port.to_i < 1 or port.to_i > 65535) -%>
+  bind <%= ip -%>:<%= port -%> <%= Array(@bind[virtual_ip]).join(" ") %>
+<%- end else
+  Array(@ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port|
+  begin
+    IPAddr.new(virtual_ip)
+    valid_ip = true
+  rescue ArgumentError => e
+    valid_ip = false
+  end
+  if ! valid_ip and ! virtual_ip.match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and virtual_ip != "*"
+    scope.function_fail(["Invalid IP address or hostname [#{virtual_ip}]"])
+  end
+  scope.function_fail(["Port [#{port}] is outside of range 1-65535"]) if port.to_i < 1 or port.to_i > 65535 -%>
+  bind <%= virtual_ip -%>:<%= port -%> <%= Array(@bind_options).join(" ") %>
+<%- end end end -%>


### PR DESCRIPTION
Currently the module does not allow to specify specific bind options
per IP we are binding haproxy onto.
Hence, if a user has a service available across several network, but
with different haproxy bind option according to the network, s/he can't
configure haproxy with the current state of this module.

It aims to make it possible to have configuration as the following:

```
  bind 192.168.2.1:80 ssl crt public.puppetlabs.com.crt
  bind 10.0.0.1:80 ssl crt private.puppetlabs.com.crt
  bind 178.35.67.12:80
```

by doing

``` puppet
haproxy::listen {'apache00' : 
  ports => '80',
  ipaddresses_and_bind_options => {'192.168.2.1'  => ['ssl', 'crt', 'public.puppetlabs.com.crt'],
                                   '10.0.0.1'     => ['ssl', 'crt', 'private.puppetlabs.com.crt'],
                                   '178.35.67.12' => []},
}
```
