### PR TITLE
parameterize configuration defaults in haproxy::params

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ node 'haproxy-server' {
 ###Configuring haproxy options
 
 The main [`haproxy` class](#class-haproxy) has many options for configuring your HAProxy server. 
+The following represents the default values.
 
 ```puppet
 class { 'haproxy':
@@ -100,6 +101,15 @@ class { 'haproxy':
     'maxconn' => '8000',
   },
 }
+```
+
+But if you only want to change one or two of those defaults, try this:
+
+```
+class { 'haproxy':
+    global_log => '127.0.0.1 local0',
+    defaults_maxconn => '4000',
+  }
 ```
 
 ###Configuring HAProxy daemon listener

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,26 @@ class haproxy (
   $restart_command  = undef,
   $custom_fragment  = undef,
 
+  $global_log       = "${::ipaddress} local0",
+  $global_chroot    = '/var/lib/haproxy',
+  $global_pidfile   = '/var/run/haproxy.pid',
+  $global_maxconn   = '4000',
+  $global_user      = 'haproxy',
+  $global_group     = 'haproxy',
+  $global_daemon    = '',
+  $global_stats     = 'socket /var/lib/haproxy/stats'
+  $defaults_log     = 'global',
+  $defaults_stats   = 'enable',
+  $defaults_option  = 'redispatch',
+  $defaults_retries = '3',
+  $defaults_timeout_http_request = '10s',
+  $defaults_timeout_queue   = '1m',
+  $defaults_timeout_connect = '10s',
+  $defaults_timeout_client  = '1m',
+  $defaults_timeout_server  = '1m',
+  $defaults_timeout_check   = '10s',
+  $defaults_maxconn = '8000'
+
   # Deprecated
   $manage_service   = undef,
   $enable           = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,7 +95,7 @@ class haproxy (
   $global_user      = 'haproxy',
   $global_group     = 'haproxy',
   $global_daemon    = '',
-  $global_stats     = 'socket /var/lib/haproxy/stats'
+  $global_stats     = 'socket /var/lib/haproxy/stats',
   $defaults_log     = 'global',
   $defaults_stats   = 'enable',
   $defaults_option  = 'redispatch',
@@ -106,7 +106,7 @@ class haproxy (
   $defaults_timeout_client  = '1m',
   $defaults_timeout_server  = '1m',
   $defaults_timeout_check   = '10s',
-  $defaults_maxconn = '8000'
+  $defaults_maxconn = '8000',
 
   # Deprecated
   $manage_service   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,18 +24,6 @@
 # [*service_manage*]
 #   Chooses whether the haproxy service state should be managed by puppet at all. Defaults to true
 #
-# [*global_options*]
-#   A hash of all the haproxy global options. If you want to specify more
-#    than one option (i.e. multiple timeout or stats options), pass those
-#    options as an array and you will get a line for each of them in the
-#    resultant haproxy.cfg file.
-#
-# [*defaults_options*]
-#   A hash of all the haproxy defaults options. If you want to specify more
-#    than one option (i.e. multiple timeout or stats options), pass those
-#    options as an array and you will get a line for each of them in the
-#    resultant haproxy.cfg file.
-#
 #[*restart_command*]
 #   Command to use when restarting the on config changes.
 #    Passed directly as the <code>'restart'</code> parameter to the service resource.
@@ -47,6 +35,39 @@
 #  the defined resources such as haproxy::listen when an operater would rather
 #  just write plain configuration. Accepts a string (ie, output from the
 #  template() function). Defaults to undef
+#
+# [*global_options*]
+#    This option has been removed to accomodate individual control over parameters 
+#    which are now used to build this data structure.  The legacy defaults for this 
+#    data structure are preserved, but may now be over-ridden one at a time, without 
+#    the need to reproduce this entire hash when invoking this module.
+#
+#        $global_log
+#        $global_chroot
+#        $global_pidfile
+#        $global_maxconn
+#        $global_user
+#        $global_group
+#        $global_daemon
+#        $global_stats
+#
+# [*defaults_options*]
+#    This option has been removed to accomodate individual control over parameters 
+#    which are now used to build this data structure.  The legacy defaults for this 
+#    data structure are preserved, but may now be over-ridden one at a time, without 
+#    the need to reproduce this entire hash when invoking this module.
+#
+#        $defaults_log
+#        $defaults_stats
+#        $defaults_option
+#        $defaults_retries
+#        $defaults_timeout_http_request
+#        $defaults_timeout_queue
+#        $defaults_timeout_connect
+#        $defaults_timeout_client
+#        $defaults_timeout_server
+#        $defaults_timeout_check
+#        $defaults_maxconn
 #
 # === Examples
 #
@@ -83,36 +104,68 @@ class haproxy (
   $package_name     = $haproxy::params::package_name,
   $service_ensure   = 'running',
   $service_manage   = true,
-  $global_options   = $haproxy::params::global_options,
-  $defaults_options = $haproxy::params::defaults_options,
+  # $global_options   = $haproxy::params::global_options,
+  # $defaults_options = $haproxy::params::defaults_options,
   $restart_command  = undef,
   $custom_fragment  = undef,
 
-  $global_log       = "${::ipaddress} local0",
-  $global_chroot    = '/var/lib/haproxy',
-  $global_pidfile   = '/var/run/haproxy.pid',
-  $global_maxconn   = '4000',
-  $global_user      = 'haproxy',
-  $global_group     = 'haproxy',
-  $global_daemon    = '',
-  $global_stats     = 'socket /var/lib/haproxy/stats',
-  $defaults_log     = 'global',
-  $defaults_stats   = 'enable',
-  $defaults_option  = 'redispatch',
-  $defaults_retries = '3',
-  $defaults_timeout_http_request = '10s',
-  $defaults_timeout_queue   = '1m',
-  $defaults_timeout_connect = '10s',
-  $defaults_timeout_client  = '1m',
-  $defaults_timeout_server  = '1m',
-  $defaults_timeout_check   = '10s',
-  $defaults_maxconn = '8000',
+  $global_log       = $haproxy::params::_global_log,
+  $global_chroot    = $haproxy::params::_global_chroot,
+  $global_pidfile   = $haproxy::params::_global_pidfile,
+  $global_maxconn   = $haproxy::params::_global_maxconn,
+  $global_user      = $haproxy::params::_global_user,
+  $global_group     = $haproxy::params::_global_group,
+  $global_daemon    = $haproxy::params::_global_daemon,
+  $global_stats     = $haproxy::params::_global_stats,
+  $defaults_log     = $haproxy::params::_defaults_log,
+  $defaults_stats   = $haproxy::params::_defaults_stats,
+  $defaults_option  = $haproxy::params::_defaults_option,
+  $defaults_retries = $haproxy::params::_defaults_retries,
+  $defaults_timeout_http_request = $haproxy::params::_defaults_timeout_http_request,
+  $defaults_timeout_queue   = $haproxy::params::_defaults_timeout_queue,
+  $defaults_timeout_connect = $haproxy::params::_defaults_timeout_connect,
+  $defaults_timeout_client  = $haproxy::params::_defaults_timeout_client,
+  $defaults_timeout_server  = $haproxy::params::_defaults_timeout_server,
+  $defaults_timeout_check   = $haproxy::params::_defaults_timeout_check,
+  $defaults_maxconn = $haproxy::params::_defaults_maxconn,
 
   # Deprecated
   $manage_service   = undef,
   $enable           = undef,
 ) inherits haproxy::params {
   include concat::setup
+
+  case $::osfamily {
+    'Archlinux', 'Debian', 'Redhat': {
+      # $package_name     = 'haproxy'
+      $global_options   = {
+        'log'     => $global_log, 
+        'chroot'  => $global_chroot,
+        'pidfile' => $global_pidfile, 
+        'maxconn' => $global_maxconn, 
+        'user'    => $global_user, 
+        'group'   => $global_group, 
+        'daemon'  => $global_daemon, 
+        'stats'   => $global_stats, 
+      }
+      $defaults_options = {
+        'log'     => $defaults_log, 
+        'stats'   => $defaults_stats, 
+        'option'  => $defaults_option, 
+        'retries' => $defaults_retries, 
+        'timeout' => [
+          "http-request $defaults_timeout_http_request",
+          "queue $defaults_timeout_queue",
+          "connect $defaults_timeout_connect",
+          "client $defaults_timeout_client",
+          "server $defaults_timeout_server",
+          "check $defaults_timeout_check",
+        ],
+        'maxconn' => $defaults_maxconn, 
+      }
+    }
+    default: { fail("The ${::osfamily} operating system is not supported with the haproxy module") }
+  }
 
   if $service_ensure != true and $service_ensure != false {
     if ! ($service_ensure in [ 'running','stopped']) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,11 +9,6 @@
 #  uses storeconfigs on the Puppet Master to export/collect resources
 #  from all balancer members.
 #
-#  The use of the each([]) array iterator below requires 'main.parser = future' 
-#  to be set in the master's puppet.conf.  The experimental features made available 
-#  by the future parser come along with many non-backwards compatible changes 
-#  known to break multiple features of existing manifests.
-#
 # === Parameters
 #
 # [*package_ensure*]
@@ -109,8 +104,8 @@ class haproxy (
   $package_name     = $haproxy::params::package_name,
   $service_ensure   = 'running',
   $service_manage   = true,
-  $global_options   = undef,
-  $defaults_options = undef, 
+  # $global_options   = $haproxy::params::global_options,
+  # $defaults_options = $haproxy::params::defaults_options,
   $restart_command  = undef,
   $custom_fragment  = undef,
 
@@ -143,69 +138,30 @@ class haproxy (
   case $::osfamily {
     'Archlinux', 'Debian', 'Redhat': {
       # $package_name     = 'haproxy'
-      if( ! is_hash( $global_options ) ){
-        $global_options   = {
-          'log'     => $global_log, 
-          'chroot'  => $global_chroot,
-          'pidfile' => $global_pidfile, 
-          'maxconn' => $global_maxconn, 
-          'user'    => $global_user, 
-          'group'   => $global_group, 
-          'daemon'  => $global_daemon, 
-          'stats'   => $global_stats, 
-        }
+      $global_options   = {
+        'log'     => $global_log, 
+        'chroot'  => $global_chroot,
+        'pidfile' => $global_pidfile, 
+        'maxconn' => $global_maxconn, 
+        'user'    => $global_user, 
+        'group'   => $global_group, 
+        'daemon'  => $global_daemon, 
+        'stats'   => $global_stats, 
       }
-      $ignore_global_defaults = 0
-      $the_global_options = [ 'log', 'chroot', 'pidfile', 'maxconn', 'user', 'group', 'daemon', 'stats' ]
-      each( $the_global_options ) |$option| {
-        $param_value = ${global_${option}}
-        $default_value = ${global_${option}}
-        if( $param_value != $default_value ){
-          $ignore_global_defaults = 1
-        }
-      }
-      if( $ignore_global_defaults = 0 ){
-        $global_options   = $haproxy::params::_global_options
-      }
-      if( ! is_hash( $defaults_options ) ){
-        $defaults_options = {
-          'log'     => $defaults_log, 
-          'stats'   => $defaults_stats, 
-          'option'  => $defaults_option, 
-          'retries' => $defaults_retries, 
-          'timeout' => [
-            "http-request $defaults_timeout_http_request",
-            "queue $defaults_timeout_queue",
-            "connect $defaults_timeout_connect",
-            "client $defaults_timeout_client",
-            "server $defaults_timeout_server",
-            "check $defaults_timeout_check",
-          ],
-          'maxconn' => $defaults_maxconn, 
-        }
-      }
-      $ignore_defaults_defaults = 0
-      $the_defaults_options = [ 'log', 'stats', 'option', 'retries', 'maxconn' ]
-      each( $the_defaults_options ) |$option| {
-        $param_value = ${defaults_${option}}
-        $default_value = ${defaults_${option}}
-        if( $param_value != $default_value ){
-          $ignore_defaults_defaults = 1
-        }
-      }
-      $ignore_defaults_timeout_defaults = 0
-      $the_defaults_timeout_options = [ 'http_request', 'queue', 'connect', 'client', 'server', 'check' ]
-      each( $the_defaults_timeout_options ) |$option| {
-        $param_value = ${defaults_timeout_${option}}
-        $default_value = ${defaults_timeout_${option}}
-        if( $param_value != $default_value ){
-          $ignore_defaults_timeout_defaults = 1
-        }
-      }
-      if( $ignore_defaults_defaults = 0 ){
-        if( $ignore_defaults_timeout_defaults = 0 ){
-          $defaults_options = $haproxy::params::_defaults_options,
-        }
+      $defaults_options = {
+        'log'     => $defaults_log, 
+        'stats'   => $defaults_stats, 
+        'option'  => $defaults_option, 
+        'retries' => $defaults_retries, 
+        'timeout' => [
+          "http-request $defaults_timeout_http_request",
+          "queue $defaults_timeout_queue",
+          "connect $defaults_timeout_connect",
+          "client $defaults_timeout_client",
+          "server $defaults_timeout_server",
+          "check $defaults_timeout_check",
+        ],
+        'maxconn' => $defaults_maxconn, 
       }
     }
     default: { fail("The ${::osfamily} operating system is not supported with the haproxy module") }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,29 +9,29 @@ class haproxy::params {
     'Archlinux', 'Debian', 'Redhat': {
       $package_name     = 'haproxy'
       $global_options   = {
-        'log'     => "${::ipaddress} local0",
-        'chroot'  => '/var/lib/haproxy',
-        'pidfile' => '/var/run/haproxy.pid',
-        'maxconn' => '4000',
-        'user'    => 'haproxy',
-        'group'   => 'haproxy',
-        'daemon'  => '',
-        'stats'   => 'socket /var/lib/haproxy/stats'
+        'log'     => $global_log, 
+        'chroot'  => $global_chroot. 
+        'pidfile' => $global_pidfile, 
+        'maxconn' => $global_maxconn, 
+        'user'    => $global_user, 
+        'group'   => $global_group, 
+        'daemon'  => $global_daemon, 
+        'stats'   => $global_stats, 
       }
       $defaults_options = {
-        'log'     => 'global',
-        'stats'   => 'enable',
-        'option'  => 'redispatch',
-        'retries' => '3',
+        'log'     => $defaults_log, 
+        'stats'   => $defaults_stats, 
+        'option'  => $defaults_option, 
+        'retries' => $defaults_retries, 
         'timeout' => [
-          'http-request 10s',
-          'queue 1m',
-          'connect 10s',
-          'client 1m',
-          'server 1m',
-          'check 10s',
+          "http-request $defaults_timeout_http_request",
+          "queue $defaults_timeout_queue",
+          "connect $defaults_timeout_connect",
+          "client $defaults_timeout_client",
+          "server $defaults_timeout_server",
+          "check $defaults_timeout_check",
         ],
-        'maxconn' => '8000'
+        'maxconn' => $defaults_maxconn, 
       }
     }
     default: { fail("The ${::osfamily} operating system is not supported with the haproxy module") }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class haproxy::params {
       $package_name     = 'haproxy'
       $global_options   = {
         'log'     => $global_log, 
-        'chroot'  => $global_chroot. 
+        'chroot'  => $global_chroot,
         'pidfile' => $global_pidfile, 
         'maxconn' => $global_maxconn, 
         'user'    => $global_user, 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,39 +1,31 @@
 # == Class: haproxy::params
 #
-# This is a container class holding default parameters for for haproxy class.
-#  currently, only the Redhat family is supported, but this can be easily
-#  extended by changing package names and configuration file paths.
+# This is a container class holding default parameters for haproxy class.
+#  currently, only the Redhat, Debian and Archlinux families are supported, 
+# but this can be easily extended by changing package names and configuration 
+# file paths.
 #
 class haproxy::params {
-  case $::osfamily {
-    'Archlinux', 'Debian', 'Redhat': {
-      $package_name     = 'haproxy'
-      $global_options   = {
-        'log'     => $global_log, 
-        'chroot'  => $global_chroot,
-        'pidfile' => $global_pidfile, 
-        'maxconn' => $global_maxconn, 
-        'user'    => $global_user, 
-        'group'   => $global_group, 
-        'daemon'  => $global_daemon, 
-        'stats'   => $global_stats, 
-      }
-      $defaults_options = {
-        'log'     => $defaults_log, 
-        'stats'   => $defaults_stats, 
-        'option'  => $defaults_option, 
-        'retries' => $defaults_retries, 
-        'timeout' => [
-          "http-request $defaults_timeout_http_request",
-          "queue $defaults_timeout_queue",
-          "connect $defaults_timeout_connect",
-          "client $defaults_timeout_client",
-          "server $defaults_timeout_server",
-          "check $defaults_timeout_check",
-        ],
-        'maxconn' => $defaults_maxconn, 
-      }
-    }
-    default: { fail("The ${::osfamily} operating system is not supported with the haproxy module") }
-  }
+
+  $package_name      = 'haproxy'
+  $_global_log       = "${::ipaddress} local0"
+  $_global_chroot    = '/var/lib/haproxy'
+  $_global_pidfile   = '/var/run/haproxy.pid'
+  $_global_maxconn   = '4000'
+  $_global_user      = 'haproxy'
+  $_global_group     = 'haproxy'
+  $_global_daemon    = ''
+  $_global_stats     = 'socket /var/lib/haproxy/stats'
+  $_defaults_log     = 'global'
+  $_defaults_stats   = 'enable'
+  $_defaults_option  = 'redispatch'
+  $_defaults_retries = '3'
+  $_defaults_timeout_http_request = '10s'
+  $_defaults_timeout_queue   = '1m'
+  $_defaults_timeout_connect = '10s'
+  $_defaults_timeout_client  = '1m'
+  $_defaults_timeout_server  = '1m'
+  $_defaults_timeout_check   = '10s'
+  $_defaults_maxconn = '8000'
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,4 +28,30 @@ class haproxy::params {
   $_defaults_timeout_check   = '10s'
   $_defaults_maxconn = '8000'
 
+  $_global_options   = {
+    'log'     => "${::ipaddress} local0",
+    'chroot'  => '/var/lib/haproxy',
+    'pidfile' => '/var/run/haproxy.pid',
+    'maxconn' => '4000',
+    'user'    => 'haproxy',
+    'group'   => 'haproxy',
+    'daemon'  => '',
+    'stats'   => 'socket /var/lib/haproxy/stats'
+  }
+  $_defaults_options = {
+    'log'     => 'global',
+    'stats'   => 'enable',
+    'option'  => 'redispatch',
+    'retries' => '3',
+    'timeout' => [
+      'http-request 10s',
+      'queue 1m',
+      'connect 10s',
+      'client 1m',
+      'server 1m',
+      'check 10s',
+    ],
+    'maxconn' => '8000'
+  }
+
 }


### PR DESCRIPTION
One should be able to over-ride a single value, I think, without having to reproduce the entire default configuration. 

https://gist.github.com/anonymous/0d13f92a1b1355596393  

The initial pull request was premature.  ~~You~~do~~not~~want~~to~~merge~~it~~quite~~yet~~.  I'm sorting out the issues and will update this comment again, once it is ready for your consideration.  

OK, I have now successfully manually tested this, and it again builds the default configuration, while now permitting individual options to be over-ridden like so:

```
  class { 'haproxy':
    global_log => '127.0.0.1 local0',
  }

```

And another concern: this code breaks backwards compatibility.  Working to fix that next.  You do not want to merge this until that has been handled.  
