### PR TITLE
Add support for ssl specific options to bind.

### DIFF
--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -65,6 +65,7 @@ define haproxy::frontend (
   $ipaddress        = [$::ipaddress],
   $mode             = undef,
   $bind_options     = undef,
+  $bind_options_ssl = undef,
   $collect_exported = true,
   $options          = {
     'option'  => [

--- a/templates/fragments/_bind.erb
+++ b/templates/fragments/_bind.erb
@@ -12,5 +12,9 @@
     end
   -%>
   <%- scope.function_fail(["Port [#{port}] is outside of range 1-65535"]) if port.to_i < 1 or port.to_i > 65535 -%>
-  bind <%= virtual_ip %>:<%= port %> <%= Array(@bind_options).join(" ") %>
+  <% if port.to_i == 443 -%>
+bind <%= virtual_ip %>:<%= port %> <%= Array(@bind_options_ssl).join(' ') %>
+  <% else -%>
+bind <%= virtual_ip %>:<%= port %> <%= Array(@bind_options).join(' ') %>
+  <% end -%>
 <% end end -%>


### PR DESCRIPTION
Change adds support for configuring bind options based on whether it is port 443 (ssl) or something different.
Needed to be able to do things like this: https://raymii.org/s/tutorials/haproxy_client_side_ssl_certificates.html

Removed some indentation to make the resulting configuration file look better.
