### PR TITLE
make bind option actually work - ie. do not set  ipaddress per default

### DIFF
--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -67,7 +67,7 @@
 #
 define haproxy::frontend (
   $ports            = undef,
-  $ipaddress        = [$::ipaddress],
+  $ipaddress        = undef,
   $bind             = undef,
   $mode             = undef,
   $collect_exported = true,
@@ -80,6 +80,9 @@ define haproxy::frontend (
   $bind_options     = '',
 ) {
 
+  if ! $bind and ! $ipaddress {
+    $ipaddress = $::ipaddress
+  }
   if $ports and $bind {
     fail('The use of $ports and $bind is mutually exclusive, please choose either one')
   }

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -77,7 +77,7 @@
 #
 define haproxy::listen (
   $ports                        = undef,
-  $ipaddress                    = [$::ipaddress],
+  $ipaddress                    = undef,
   $bind                         = undef,
   $mode                         = undef,
   $collect_exported             = true,
@@ -92,6 +92,9 @@ define haproxy::listen (
   $bind_options                 = '',
 ) {
 
+  if ! $bind and ! $ipaddress {
+    $ipaddress = $::ipaddress
+  }
   if $ports and $bind {
     fail('The use of $ports and $bind is mutually exclusive, please choose either one')
   }


### PR DESCRIPTION
Using the new bind option, makes haproxy frontend and listen complain about ipaddress AND bind being set.. because ipaddress is per default.

I set it to undef per default, and then set it to the default value ($::ipaddress), ONLY if $bind was not set and no $ipaddress argument was given - so old behavior is kept.