### PR TITLE
add Gentoo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ An array of groups in the userlist. See http://cbonte.github.io/haproxy-dconv/co
 
 ##Limitations
 
-RedHat and Debian family OSes are officially supported. Tested and built on Ubuntu and CentOS. 
+RedHat and Debian family OSes are officially supported. Tested and built on Ubuntu, CentOS, Gentoo. 
 
 ##Development
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,4 +8,12 @@ class haproxy::install inherits haproxy {
     ensure  => $_package_ensure,
     alias   => 'haproxy',
   }
+
+  # Create default configuration directory, gentoo portage does not create it
+  file { '/etc/haproxy':
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    require => Package["$package_name"]
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@
 #
 class haproxy::params {
   case $::osfamily {
-    'Archlinux', 'Debian', 'Redhat': {
+    'Archlinux', 'Debian', 'Redhat', 'Gentoo' : {
       $package_name     = 'haproxy'
       $global_options   = {
         'log'     => "${::ipaddress} local0",

--- a/metadata.json
+++ b/metadata.json
@@ -54,6 +54,9 @@
         "12.04",
         "14.04"
       ]
+    },
+    {
+      "operatingsystem": "Gentoo"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Create default configuration directory /etc/haproxy, gentoo portage does not create it