### PR TITLE
bind parameter use while still allowing ipaddress to have a default.

### DIFF
--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -67,7 +67,7 @@
 #
 define haproxy::frontend (
   $ports            = undef,
-  $ipaddress        = [$::ipaddress],
+  $ipaddress        = undef,
   $bind             = undef,
   $mode             = undef,
   $collect_exported = true,
@@ -80,6 +80,11 @@ define haproxy::frontend (
   $bind_options     = '',
 ) {
 
+  if ! $bind and ! $ipaddress {
+    $_ipaddress = $::ipaddress
+  } else {
+    $_ipaddress = $ipaddress
+  }
   if $ports and $bind {
     fail('The use of $ports and $bind is mutually exclusive, please choose either one')
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,8 +94,8 @@ class haproxy (
 ) inherits haproxy::params {
 
   if $service_ensure != true and $service_ensure != false {
-    if ! ($service_ensure in [ 'running','stopped']) {
-      fail('service_ensure parameter must be running, stopped, true, or false')
+    if ! ($service_ensure in [ 'running','stopped','unmanaged']) {
+      fail('service_ensure parameter must be running, stopped, true, false or unmanaged')
     }
   }
   validate_string($package_name,$package_ensure)
@@ -113,7 +113,11 @@ class haproxy (
     }
   } else {
     $_package_ensure = $package_ensure
-    $_service_ensure = $service_ensure
+    if $service_ensure == 'unmanaged' {
+      $_service_ensure = undef
+    } else {
+      $_service_ensure = $service_ensure
+    }
   }
 
   # To support deprecating $manage_service

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -77,7 +77,7 @@
 #
 define haproxy::listen (
   $ports                        = undef,
-  $ipaddress                    = [$::ipaddress],
+  $ipaddress                    = undef,
   $bind                         = undef,
   $mode                         = undef,
   $collect_exported             = true,
@@ -92,6 +92,11 @@ define haproxy::listen (
   $bind_options                 = '',
 ) {
 
+  if ! $bind and ! $ipaddress {
+    $_ipaddress = $::ipaddress
+  } else {
+    $_ipaddress = $ipaddress
+  }
   if $ports and $bind {
     fail('The use of $ports and $bind is mutually exclusive, please choose either one')
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,9 +15,10 @@ class haproxy::service inherits haproxy {
     service { 'haproxy':
       ensure     => $_service_ensure,
       enable     => $_service_ensure ? {
-        'running' => true,
-        'stopped' => false,
-        default   => $_service_ensure,
+        'running'   => true,
+        'stopped'   => false,
+        'unmanaged' => false,
+        default     => $_service_ensure,
       },
       name       => 'haproxy',
       hasrestart => true,

--- a/templates/fragments/_bind.erb
+++ b/templates/fragments/_bind.erb
@@ -19,7 +19,7 @@
   scope.function_fail(["Port #{port} for IP #{ip} is outside of range 1-65535"]) if port and (port.to_i < 1 or port.to_i > 65535) -%>
   bind <%= ip -%>:<%= port -%> <%= Array(@bind[virtual_ip]).join(" ") %>
 <%- end else
-  Array(@ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port|
+  Array(@_ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port|
   begin
     IPAddr.new(virtual_ip)
     valid_ip = true


### PR DESCRIPTION
This is a replacement for https://github.com/puppetlabs/puppetlabs-haproxy/pull/132 that fixes the ipaddress redefinition.