### PR TITLE
Allow puppet to manage the haproxy service to prevent starting at boot b...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,8 +94,8 @@ class haproxy (
 ) inherits haproxy::params {
 
   if $service_ensure != true and $service_ensure != false {
-    if ! ($service_ensure in [ 'running','stopped']) {
-      fail('service_ensure parameter must be running, stopped, true, or false')
+    if ! ($service_ensure in [ 'running','stopped','unmanaged']) {
+      fail('service_ensure parameter must be running, stopped, true, false or unmanaged')
     }
   }
   validate_string($package_name,$package_ensure)
@@ -113,7 +113,11 @@ class haproxy (
     }
   } else {
     $_package_ensure = $package_ensure
-    $_service_ensure = $service_ensure
+    if $service_ensure == 'unmanaged' {
+      $_service_ensure = undef
+    } else {
+      $_service_ensure = $service_ensure
+    }
   }
 
   # To support deprecating $manage_service

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,9 +15,10 @@ class haproxy::service inherits haproxy {
     service { 'haproxy':
       ensure     => $_service_ensure,
       enable     => $_service_ensure ? {
-        'running' => true,
-        'stopped' => false,
-        default   => $_service_ensure,
+        'running'   => true,
+        'stopped'   => false,
+        'unmanaged' => false,
+        default     => $_service_ensure,
       },
       name       => 'haproxy',
       hasrestart => true,


### PR DESCRIPTION
...ut not manage its running state.

This replaces https://github.com/puppetlabs/puppetlabs-haproxy/pull/84 to allow cluster manged runstate of haproxy and puppet managing the service to disabled on boot.