### PR TITLE
MODULES-1619 Add haproxy version fact

### DIFF
--- a/lib/facter/haproxy_version.rb
+++ b/lib/facter/haproxy_version.rb
@@ -1,0 +1,20 @@
+# Fact: haproxy_version
+#
+# Purpose: get haproxy's current version
+#
+# Resolution:
+#   Uses haproxy's -v flag and parses the result from 'version'
+#
+# Caveats:
+#   none
+#
+# Notes:
+#   None
+Facter.add('haproxy_version') do
+  haproxy_version_cmd = 'haproxy -v 2>&1'
+  haproxy_version_result = Facter::Util::Resolution.exec(haproxy_version_cmd)
+  setcode do
+    haproxy_version_result.to_s.lines.first.strip.split(/HA-Proxy/)[1].strip.split(/version/)[1].strip.split(/((\d+\.){2,}\d+).*/)[1]
+  end
+end
+

--- a/lib/facter/haproxy_version.rb
+++ b/lib/facter/haproxy_version.rb
@@ -10,11 +10,13 @@
 #
 # Notes:
 #   None
-Facter.add('haproxy_version') do
-  haproxy_version_cmd = 'haproxy -v 2>&1'
-  haproxy_version_result = Facter::Util::Resolution.exec(haproxy_version_cmd)
-  setcode do
-    haproxy_version_result.to_s.lines.first.strip.split(/HA-Proxy/)[1].strip.split(/version/)[1].strip.split(/((\d+\.){2,}\d+).*/)[1]
+if Facter::Util::Resolution.which('haproxy')
+  Facter.add('haproxy_version') do
+    haproxy_version_cmd = 'haproxy -v 2>&1'
+    haproxy_version_result = Facter::Util::Resolution.exec(haproxy_version_cmd)
+    setcode do
+      haproxy_version_result.to_s.lines.first.strip.split(/HA-Proxy/)[1].strip.split(/version/)[1].strip.split(/((\d+\.){2,}\d+).*/)[1]
+    end
   end
 end
 

--- a/spec/unit/facter/haproxy_version_spec.rb
+++ b/spec/unit/facter/haproxy_version_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+  }
+
+  it do
+    haproxy_version_output = <<-EOS
+HA-Proxy version 1.5.3 2014/07/25
+Copyright 2000-2014 Willy Tarreau <w@1wt.eu>
+    EOS
+    Facter::Util::Resolution.expects(:exec).with("haproxy -v 2>&1").returns(haproxy_version_output)
+    Facter.fact(:haproxy_version).value.should == "1.5.3"
+  end
+end

--- a/spec/unit/facter/haproxy_version_spec.rb
+++ b/spec/unit/facter/haproxy_version_spec.rb
@@ -5,12 +5,22 @@ describe Facter::Util::Fact do
     Facter.clear
   }
 
-  it do
-    haproxy_version_output = <<-EOS
-HA-Proxy version 1.5.3 2014/07/25
-Copyright 2000-2014 Willy Tarreau <w@1wt.eu>
-    EOS
-    Facter::Util::Resolution.expects(:exec).with("haproxy -v 2>&1").returns(haproxy_version_output)
-    Facter.fact(:haproxy_version).value.should == "1.5.3"
+  context "haproxy present" do
+    it do
+      haproxy_version_output = <<-EOS
+      HA-Proxy version 1.5.3 2014/07/25
+      Copyright 2000-2014 Willy Tarreau <w@1wt.eu>
+      EOS
+      Facter::Util::Resolution.expects(:which).with("haproxy").returns(true)
+      Facter::Util::Resolution.expects(:exec).with("haproxy -v 2>&1").returns(haproxy_version_output)
+      Facter.fact(:haproxy_version).value.should == "1.5.3"
+    end
+  end
+
+  context "haproxy not present" do
+    it do
+      Facter::Util::Resolution.expects(:which).with("haproxy").returns(false)
+      Facter.fact(:haproxy_version).should be_nil
+    end
   end
 end

--- a/spec/unit/facter/haproxy_version_spec.rb
+++ b/spec/unit/facter/haproxy_version_spec.rb
@@ -19,6 +19,7 @@ describe Facter::Util::Fact do
 
   context "haproxy not present" do
     it do
+      Facter::Util::Resolution.stubs(:exec)
       Facter::Util::Resolution.expects(:which).with("haproxy").returns(false)
       Facter.fact(:haproxy_version).should be_nil
     end


### PR DESCRIPTION
There are some haproxy config settings and features that are version dependant, so it'd be cool if we could find out what version of Haproxy is running before adding them etc.