### PR TITLE
Corrected namespaces on variables

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -98,8 +98,8 @@ define haproxy::balancermember (
 
   # Template uses $ipaddresses, $server_name, $ports, $option
   concat::fragment { "${listening_service}_balancermember_${name}":
-    order   => "20-${listening_service}-01-${name}",
     ensure  => $ensure,
+    order   => "20-${listening_service}-01-${name}",
     target  => '/etc/haproxy/haproxy.cfg',
     content => template('haproxy/haproxy_balancermember.erb'),
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,11 +24,11 @@ class haproxy::config inherits haproxy {
     content => template('haproxy/haproxy-base.cfg.erb'),
   }
 
-  if $global_options['chroot'] {
-    file { $global_options['chroot']:
+  if $haproxy::global_options['chroot'] {
+    file { $haproxy::global_options['chroot']:
       ensure => directory,
-      owner  => $global_options['user'],
-      group  => $global_options['group'],
+      owner  => $haproxy::global_options['user'],
+      group  => $haproxy::global_options['group'],
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,8 +4,8 @@ class haproxy::install inherits haproxy {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  package { $package_name:
-    ensure  => $_package_ensure,
+  package { $haproxy::package_name:
+    ensure  => $haproxy::_package_ensure,
     alias   => 'haproxy',
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,10 +1,10 @@
 # Private class
 class haproxy::service inherits haproxy {
-  if $caller_module_name != $module_name {
+  if $::caller_module_name != $::module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $_service_manage {
+  if $haproxy::_service_manage {
     if ($::osfamily == 'Debian') {
       file { '/etc/default/haproxy':
         content => 'ENABLED=1',
@@ -13,16 +13,16 @@ class haproxy::service inherits haproxy {
     }
 
     service { 'haproxy':
-      ensure     => $_service_ensure,
-      enable     => $_service_ensure ? {
+      ensure     => $haproxy::_service_ensure,
+      enable     => $haproxy::_service_ensure ? {
         'running' => true,
         'stopped' => false,
-        default   => $_service_ensure,
+        default   => $haproxy::_service_ensure,
       },
       name       => 'haproxy',
       hasrestart => true,
       hasstatus  => true,
-      restart    => $restart_command,
+      restart    => $haproxy::restart_command,
     }
   }
 }


### PR DESCRIPTION
Altered variables to be compiant with "11.6. Namespacing Variables" in the Puppet Style Guide.
Moved an ensure in balancermember.pp to be first to be compliant with "9.3. Attribute Ordering".