### PR TITLE
adding a default option into nodesets

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  centos-64-x64:
+    roles:
+      - default
+    platform: el-6-x86_64
+    box : centos-64-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: foss


### PR DESCRIPTION
making centos-64-x64.yml the default in nodesets