### PR TITLE
fixing the match as it wouldn't work with a wildcard

### DIFF
--- a/templates/fragments/_bind.erb
+++ b/templates/fragments/_bind.erb
@@ -1,7 +1,7 @@
 <% require 'ipaddr' -%>
 <% if @bind
   @bind.keys.uniq.sort.each do |virtual_ip|
-  if ip_port = virtual_ip.match(/^([A-Za-z0-9\.-]+):([0-9]+)$/)
+  if ip_port = virtual_ip.match(/^([A-Za-z0-9\.-]+|\*):([0-9]+)$/)
     ip = ip_port[1]
     port = ip_port[2]
   elsif virtual_ip.match(/^([A-Za-z0-9\.-]+)$/)


### PR DESCRIPTION
Currently the _bind.erb template isn't matching the expected wildcard so the match will fail if this is used, however, it is expected as a use case elsewhere, so added in the match correct so it will handle both. 