### PR TITLE
Make `bind` parameter processing more flexible

### DIFF
--- a/spec/defines/frontend_spec.rb
+++ b/spec/defines/frontend_spec.rb
@@ -172,7 +172,7 @@ describe 'haproxy::frontend' do
     ) }
   end
 
-  context "when bind options are provided and no ip" do
+  context "when bind parameter is used without ipaddress parameter" do
     let(:params) do
       {
         :name  => 'apache',
@@ -183,6 +183,26 @@ describe 'haproxy::frontend' do
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nfrontend apache\n  bind 1.1.1.1:80 \n  option  tcplog\n"
+    ) }
+  end
+
+  context "when bind parameter is used with more complex address constructs" do
+    let(:params) do
+      {
+        :name  => 'apache',
+        :bind  => {
+          '1.1.1.1:80'                 => [],
+          ':443,:8443'                 => [ 'ssl', 'crt public.puppetlabs.com', 'no-sslv3' ],
+          '2.2.2.2:8000-8010'          => [ 'ssl', 'crt public.puppetlabs.com' ],
+          'fd@${FD_APP1}'              => [],
+          '/var/run/ssl-frontend.sock' => [ 'user root', 'mode 600', 'accept-proxy' ]
+        },
+      }
+    end
+    it { should contain_concat__fragment('apache_frontend_block').with(
+      'order'   => '15-apache-00',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "\nfrontend apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  option  tcplog\n"
     ) }
   end
 

--- a/templates/fragments/_bind.erb
+++ b/templates/fragments/_bind.erb
@@ -1,24 +1,10 @@
 <% require 'ipaddr' -%>
-<% if @bind
-  @bind.keys.uniq.sort.each do |virtual_ip|
-  if ip_port = virtual_ip.match(/^([A-Za-z0-9\.-]+):([0-9]+)$/)
-    ip = ip_port[1]
-    port = ip_port[2]
-  elsif virtual_ip.match(/^([A-Za-z0-9\.-]+)$/)
-   ip = virtual_ip
-  end
-  begin
-    IPAddr.new(ip)
-    valid_ip = true
-  rescue ArgumentError => e
-    valid_ip = false
-  end
-  if ! valid_ip and ! ip.match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and ip != "*"
-    scope.function_fail(["Invalid IP address or hostname [#{ip}]"])
-  end
-  scope.function_fail(["Port #{port} for IP #{ip} is outside of range 1-65535"]) if port and (port.to_i < 1 or port.to_i > 65535) -%>
-  bind <%= ip -%>:<%= port -%> <%= Array(@bind[virtual_ip]).join(" ") %>
-<%- end else
+<%- if @bind -%>
+<%- @bind.sort.map do |address_port, bind_params| -%>
+  bind <%= address_port -%> <%= Array(bind_params).join(" ") %>
+<%- end -%>
+<%- else -%>
+<%-
   Array(@ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port|
   begin
     IPAddr.new(virtual_ip)
@@ -29,6 +15,9 @@
   if ! valid_ip and ! virtual_ip.match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and virtual_ip != "*"
     scope.function_fail(["Invalid IP address or hostname [#{virtual_ip}]"])
   end
-  scope.function_fail(["Port [#{port}] is outside of range 1-65535"]) if port.to_i < 1 or port.to_i > 65535 -%>
+  scope.function_fail(["Port [#{port}] is outside of range 1-65535"]) if port.to_i < 1 or port.to_i > 65535
+-%>
   bind <%= virtual_ip -%>:<%= port -%> <%= Array(@bind_options).join(" ") %>
-<%- end end end -%>
+<%- end -%>
+<%- end -%>
+<%- end -%>


### PR DESCRIPTION
This fixes <https://tickets.puppetlabs.com/browse/MODULES-1741>.

HAProxy's `bind` parameter for listen and frontend services accepts
multiple ways of specifying addresses, ports, port ranges, sockets and
bind options. The template `templates/fragments/_bind.erb` that
processes the `haproxy::listen::bind` and `haproxy::frontend::bind` hash
should accomodate that, meaning specifically that it should not assume
that a valid bind configuration is universally of the format
`bind <ip address>:<port> [<options>*]`. The HAProxy documentation at
http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-bind
details how complex the `bind` configuration can be.

The `templates/fragments/_bind.erb` template now processes the `bind`
hash very simply by using the hash keys as "address and/or port" and the
key's value as a list of bind options that together make up a single
`bind` line in the resulting listen or frontend service configuration.

Most notably there is no more IP address or port validation. The values
are taken as is from the `bind` hash. The rationale behind that is
discussed in <https://tickets.puppetlabs.com/browse/MODULES-1741>.

Contains updated and expanded documentation, and updated spec tests.