### PR TITLE
MODULES-1783 Add haproxy::instance for the creation of multiple instances of haproxy ...

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
       ref: '1.0.0'
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: '2.4.0'
+      ref: '2.5.1'
   symlinks:
     haproxy: "#{source_dir}"

--- a/files/haproxy.init
+++ b/files/haproxy.init
@@ -1,0 +1,142 @@
+#!/bin/sh
+#
+# chkconfig: - 85 15
+# description: HA-Proxy is a TCP/HTTP reverse proxy which is particularly suited \
+#              for high availability environments.
+# processname: haproxy
+# config: /etc/haproxy/haproxy.cfg
+# pidfile: /var/run/haproxy.pid
+
+# Script Author: Simon Matter <simon.matter@invoca.ch>
+# Version: 2004060600
+
+# Source function library.
+if [ -f /etc/init.d/functions ]; then
+  . /etc/init.d/functions
+elif [ -f /etc/rc.d/init.d/functions ] ; then
+  . /etc/rc.d/init.d/functions
+else
+  exit 0
+fi
+
+# Source networking configuration.
+. /etc/sysconfig/network
+
+# Check that networking is up.
+[ ${NETWORKING} = "no" ] && exit 0
+
+# This is our service name
+BASENAME=`basename $0`
+if [ -L $0 ]; then
+  BASENAME=`find $0 -name $BASENAME -printf %l`
+  BASENAME=`basename $BASENAME`
+fi
+
+[ -f /etc/$BASENAME/$BASENAME.cfg ] || exit 1
+
+RETVAL=0
+
+start() {
+  /opt/haproxy/$BASENAME -c -q -f /etc/$BASENAME/$BASENAME.cfg
+  if [ $? -ne 0 ]; then
+    echo "Errors found in configuration file, check it with '$BASENAME check'."
+    return 1
+  fi
+
+  echo -n "Starting $BASENAME: "
+  daemon /opt/haproxy/$BASENAME -D -f /etc/$BASENAME/$BASENAME.cfg -p /var/run/$BASENAME.pid
+  RETVAL=$?
+  echo
+  [ $RETVAL -eq 0 ] && touch /var/lock/subsys/$BASENAME
+  return $RETVAL
+}
+
+stop() {
+  echo -n "Shutting down $BASENAME: "
+  killproc $BASENAME -USR1
+  RETVAL=$?
+  echo
+  [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/$BASENAME
+  [ $RETVAL -eq 0 ] && rm -f /var/run/$BASENAME.pid
+
+  # Try to kill it 9 more times.
+  # Every 6 seconds try to kill it.
+  for tries in 2 3 4 5 6 7 8 9 10 ; do
+    # Is it alive?
+    for sec in 1 2 3 4 5 6 ; do
+      sleep 1
+      pgrep >/dev/null -u root -f /opt/haproxy/$BASENAME
+      PGREPRETVAL1=$?
+      if [ $PGREPRETVAL1 -eq 1 ]; then
+        return $RETVAL
+      fi
+    done
+    # Yes, try to kill it.
+    echo ATTEMPT TO KILL: $tries
+    pkill -u root -f /opt/haproxy/$BASENAME
+  done
+
+  return $RETVAL
+}
+
+restart() {
+  /opt/haproxy/$BASENAME -c -q -f /etc/$BASENAME/$BASENAME.cfg
+  if [ $? -ne 0 ]; then
+    echo "Errors found in configuration file, check it with '$BASENAME check'."
+    return 1
+  fi
+  stop
+  start
+}
+
+reload() {
+  /opt/haproxy/$BASENAME -c -q -f /etc/$BASENAME/$BASENAME.cfg
+  if [ $? -ne 0 ]; then
+    echo "Errors found in configuration file, check it with '$BASENAME check'."
+    return 1
+  fi
+  /opt/haproxy/$BASENAME -D -f /etc/$BASENAME/$BASENAME.cfg -p /var/run/$BASENAME.pid -sf $(cat /var/run/$BASENAME.pid)
+}
+
+check() {
+  /opt/haproxy/$BASENAME -c -q -V -f /etc/$BASENAME/$BASENAME.cfg
+}
+
+rhstatus() {
+  status $BASENAME
+}
+
+condrestart() {
+  [ -e /var/lock/subsys/$BASENAME ] && restart || :
+}
+
+# See how we were called.
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    restart
+    ;;
+  reload)
+    reload
+    ;;
+  condrestart)
+    condrestart
+    ;;
+  status)
+    rhstatus
+    ;;
+  check)
+    check
+    ;;
+  *)
+    echo $"Usage: $BASENAME {start|stop|restart|reload|condrestart|status|check}"
+    exit 1
+esac
+ 
+exit $?
+

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -57,17 +57,30 @@ define haproxy::backend (
       'ssl-hello-chk'
     ],
     'balance' => 'roundrobin'
-  }
+  },
+  $instance = 'haproxy',
 ) {
 
   if defined(Haproxy::Listen[$name]) {
     fail("An haproxy::listen resource was discovered with the same name (${name}) which is not supported")
   }
 
+  # We derive settings so that the caller only has to specify $instance.
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    #$config_dir = $haproxy::params::config_dir
+    $config_file = $haproxy::params::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    #$config_dir = inline_template($haproxy::params::config_dir_tmpl)
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
   # Template uses: $name, $ipaddress, $ports, $options
-  concat::fragment { "${name}_backend_block":
+  concat::fragment { "${instance_name}-${name}_backend_block":
     order   => "20-${name}-00",
-    target  => $::haproxy::config_file,
+    target  => $config_file,
     content => template('haproxy/haproxy_backend_block.erb'),
   }
 

--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -93,14 +93,27 @@ define haproxy::balancermember (
   $ipaddresses  = $::ipaddress,
   $ensure       = 'present',
   $options      = '',
-  $define_cookies = false
+  $define_cookies = false,
+  $instance     = 'haproxy',
 ) {
 
+  # We derive these settings so that the caller only has to specify $instance.
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    #$config_dir = $haproxy::params::config_dir
+    $config_file = $haproxy::params::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    #$config_dir = inline_template($haproxy::params::config_dir_tmpl)
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
   # Template uses $ipaddresses, $server_name, $ports, $option
-  concat::fragment { "${listening_service}_balancermember_${name}":
+  concat::fragment { "${instance_name}-${listening_service}_balancermember_${name}":
     ensure  => $ensure,
     order   => "20-${listening_service}-01-${name}",
-    target  => $::haproxy::config_file,
+    target  => $config_file,
     content => template('haproxy/haproxy_balancermember.erb'),
   }
 }

--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -76,6 +76,7 @@ define haproxy::frontend (
       'tcplog',
     ],
   },
+  $instance     = 'haproxy',
   # Deprecated
   $bind_options     = '',
 ) {
@@ -92,10 +93,23 @@ define haproxy::frontend (
   if $bind {
     validate_hash($bind)
   }
+
+  # We derive these settings so that the caller only has to specify $instance.
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    #$config_dir = $haproxy::params::config_dir
+    $config_file = $haproxy::params::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    #$config_dir = inline_template($haproxy::params::config_dir_tmpl)
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
   # Template uses: $name, $ipaddress, $ports, $options
-  concat::fragment { "${name}_frontend_block":
+  concat::fragment { "${instance_name}-${name}_frontend_block":
     order   => "15-${name}-00",
-    target  => $::haproxy::config_file,
+    target  => $config_file,
     content => template('haproxy/haproxy_frontend_block.erb'),
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,11 +1,16 @@
 # Private class
-class haproxy::install inherits haproxy {
+define haproxy::install (
+  $package_name = undef,
+  $package_ensure,
+) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  package { $haproxy::package_name:
-    ensure  => $haproxy::_package_ensure,
-    alias   => 'haproxy',
+  if $package_name != undef {
+    package { $package_name:
+      ensure => $package_ensure,
+      alias  => 'haproxy',
+    }
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,0 +1,223 @@
+# == Define Resource Type: haproxy::instance
+#
+# Manages haproxy permitting multiple instances to run on the same machine.
+# Normally users use the Class['haproxy'], which runs a single haproxy
+# daemon on a machine.
+#
+# === Requirement/Dependencies:
+#
+# Currently requires the puppetlabs/concat module on the Puppet Forge and
+#  uses storeconfigs on the Puppet Master to export/collect resources
+#  from all balancer members.
+#
+# === Parameters
+#
+# [*package_ensure*]
+#   Chooses whether the haproxy package should be installed or uninstalled.
+#   Defaults to 'present'
+#
+# [*package_name*]
+#   The package name of haproxy. Defaults to undef, and no package is installed.
+#   NOTE: Class['haproxy'] has a different default.
+#   
+#
+# [*service_ensure*]
+#   Chooses whether the haproxy service should be running & enabled at boot, or
+#   stopped and disabled at boot. Defaults to 'running'
+#
+# [*service_manage*]
+#   Chooses whether the haproxy service state should be managed by puppet at
+#   all. Defaults to true
+#
+# [*global_options*]
+#   A hash of all the haproxy global options. If you want to specify more
+#    than one option (i.e. multiple timeout or stats options), pass those
+#    options as an array and you will get a line for each of them in the
+#    resultant haproxy.cfg file.
+#
+# [*defaults_options*]
+#   A hash of all the haproxy defaults options. If you want to specify more
+#    than one option (i.e. multiple timeout or stats options), pass those
+#    options as an array and you will get a line for each of them in the
+#    resultant haproxy.cfg file.
+#
+#[*restart_command*]
+#   Command to use when restarting the on config changes.
+#    Passed directly as the <code>'restart'</code> parameter to the service
+#    resource.  #    Defaults to undef i.e. whatever the service default is.
+#
+#[*custom_fragment*]
+#  Allows arbitrary HAProxy configuration to be passed through to support
+#  additional configuration not available via parameters, or to short-circuit
+#  the defined resources such as haproxy::listen when an operater would rather
+#  just write plain configuration. Accepts a string (ie, output from the
+#  template() function). Defaults to undef
+#
+#[*config_file*]
+#  Allows arbitrary config filename to be specified. If this is used,
+#  it is assumed that the directory path to the file exists and has
+#  owner/group/permissions as desired.  If set to undef, the name
+#  will be generated as follows:
+#    If $title is 'haproxy', the operating system default will be used.
+#    Otherwise, /etc/haproxy-$title/haproxy-$title.conf (Linux),
+#    or /usr/local/etc/haproxy-$title/haproxy-$title.conf (FreeBSD)
+#    The parent directory will be created automatically.
+#  Defaults to undef.
+#
+# === Examples
+#
+# A single instance of haproxy with all defaults
+# i.e. emulate Class['haproxy']
+#   package{ 'haproxy': ensure => present }->haproxy::instance { 'haproxy': }->
+#   haproxy::listen { 'puppet00':
+#     instance         => 'haproxy',
+#     collect_exported => false,
+#     ipaddress        => $::ipaddress,
+#     ports            => '8140',
+#   }
+#
+# Multiple instances of haproxy:
+#   haproxy::instance { 'group1': }
+#   haproxy::instance_service { 'group1': }
+#   haproxy::listen { 'puppet00':
+#     instance         => 'group1',
+#     collect_exported => false,
+#     ipaddress        => $::ipaddress,
+#     ports            => '8800',
+#     requires         => Package['haproxy'],
+#   }
+#   haproxy::instance { 'group2': }
+#   haproxy::instance_service { 'group2': }
+#   haproxy::listen { 'puppet00':
+#     instance         => 'group2',
+#     collect_exported => false,
+#     ipaddress        => $::ipaddress,
+#     ports            => '9900',
+#     requires         => Package['haproxy'],
+#   }
+#
+# Multiple instances of haproxy, one with a custom haproxy package:
+#   haproxy::instance { 'group1': }
+#   haproxy::instance_service { 'group1': }
+#   haproxy::listen { 'puppet00':
+#     instance         => 'group1',
+#     collect_exported => false,
+#     ipaddress        => $::ipaddress,
+#     ports            => '8800',
+#     requires         => Package['haproxy'],
+#   }
+#   haproxy::instance { 'group2': }
+#   haproxy::instance_service { 'group2': 'custom_haproxy' }
+#   haproxy::listen { 'puppet00':
+#     instance         => 'group2',
+#     collect_exported => false,
+#     ipaddress        => $::ipaddress,
+#     ports            => '9900',
+#     requires         => Package['haproxy'],
+#   }
+#
+#  When running multiple instances on one host, there must be a Service[] for
+#  each instance.  One way to create the situation where Service[] works is
+#  using haproxy::instance_service.
+#  However you may want to do it some other way. For example, you may
+#  not have packages for your custom haproxy binary. Or, you may wish
+#  to use the standard haproxy package but not create links to it, or
+#  you may have different init.d scripts.  In these cases, write your own
+#  puppet code that will result in Service[] working for you and do not
+#  call haproxy::instance_service.
+#
+define haproxy::instance (
+  $package_ensure   = 'present',
+  $package_name     = undef,
+  $service_ensure   = 'running',
+  $service_manage   = true,
+  $global_options   = undef,
+  $defaults_options = undef,
+  $restart_command  = undef,
+  $custom_fragment  = undef,
+  $config_file      = undef,
+) {
+
+  if $service_ensure != true and $service_ensure != false {
+    if ! ($service_ensure in [ 'running','stopped']) {
+      fail('service_ensure parameter must be running, stopped, true, or false')
+    }
+  }
+  validate_string($package_name,$package_ensure)
+  validate_bool($service_manage)
+
+  # Since this is a 'define', we can not use 'inherts haproxy::params'.
+  # Therefore, we "include haproxy::params" for any parameters we need.
+  if $global_options == undef {
+    include haproxy::params
+    $_global_options = $haproxy::params::global_options
+  } else {
+    $_global_options = $global_options
+  }
+  if $defaults_options == undef {
+    include haproxy::params
+    $_defaults_options = $haproxy::params::defaults_options
+  } else {
+    $_defaults_options = $defaults_options
+  }
+
+  # Determine instance_name based on:
+  #   single-instance hosts: haproxy
+  #   multi-instance hosts:  haproxy-$title
+  if $title == 'haproxy' {
+    $instance_name = 'haproxy'
+  } else {
+    $instance_name = "haproxy-${title}"
+  }
+
+  # Determine config_dir and config_file:
+  #   If config_dir defined, use it.  Otherwise:
+  #   single-instance hosts: use defaults
+  #   multi-instance hosts:  use templates
+  if $config_file != undef {
+    $_config_dir = undef
+    $_config_file = $config_file
+  } else {
+    include haproxy::params
+    if $instance_name == 'haproxy' {
+      $_config_dir = $haproxy::params::config_dir
+      $_config_file = $haproxy::params::config_file
+    } else {
+      $_config_dir = inline_template($haproxy::params::config_dir_tmpl)
+      $_config_file = inline_template($haproxy::params::config_file_tmpl)
+    }
+  }
+
+  haproxy::config { $title:
+    instance_name    => $instance_name,
+    config_dir       => $_config_dir,
+    config_file      => $_config_file,
+    global_options   => $_global_options,
+    defaults_options => $_defaults_options,
+    custom_fragment  => $custom_fragment,
+  }
+  haproxy::install { $title:
+    package_name   => $package_name,
+    package_ensure => $package_ensure,
+  }
+  haproxy::service { $title:
+    instance_name   => $instance_name,
+    service_ensure  => $service_ensure,
+    service_manage  => $service_manage,
+    restart_command => $restart_command,
+  }
+
+  if $package_ensure == 'absent' or $package_ensure == 'purged' {
+    anchor { "${title}::haproxy::begin": }
+    ~> Haproxy::Service[$title]
+    -> Haproxy::Config[$title]
+    -> Haproxy::Install[$title]
+    -> anchor { "${title}::haproxy::end": }
+  } else {
+    anchor { "${title}::haproxy::begin": }
+    -> Haproxy::Install[$title]
+    -> Haproxy::Config[$title]
+    ~> Haproxy::Service[$title]
+    -> anchor { "${title}::haproxy::end": }
+  }
+}

--- a/manifests/instance_service.pp
+++ b/manifests/instance_service.pp
@@ -1,0 +1,86 @@
+# == Define: haproxy::instance_service
+#
+# Set up the environment for an haproxy service.
+#   * Associate an haproxy instance with the haproxy package it should use.
+#   * Create the start/restart/stop functions needed by Service[].
+# In other words: sets things up so that Service[$instance_name] will work.
+#
+# In particular:
+#
+# * Create a link to the binary an instance will be using. This
+#   way each instance can link to a different binary.
+#   If you have an instance called "foo", you know "haproxy-foo"
+#   is a link to the binary it should be using.
+# * Create an init.d file named after the instance. This way
+#   Service[$instance] can start/restart the service.
+#
+# This is just one way to do this. You may want to do it
+# some other way. That is why this isn't done automatically as
+# part of haproxy::instance.
+# 
+#
+# FIXME: This hasn't been tested on FreeBSD and most likely won't work.
+# FIXME: This should take advantage of systemd when available.
+# FIXME: Update haproxy.init to sync it up with the latest packaged script.
+#
+# === Parameters
+#
+# [*haproxy_package*]
+#   The name of the package to be installed. This is useful if
+#   you package your own custom version of haproxy.
+#   Defaults to 'haproxy'
+#
+# [*bindir*]
+#   Where to put symlinks to the binary used for each instance.
+#   Defaults to '/opt/haproxy'
+#
+define haproxy::instance_service (
+  $haproxy_package = 'haproxy',
+  $bindir = '/opt/haproxy',
+) {
+
+  ensure_resource('package', $haproxy_package, {
+    'ensure' => 'present',
+  })
+
+  # Manage the parent directory.
+  ensure_resource('file', $bindir, {
+    ensure => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0744',
+  })
+
+  # Create a link named after the instance. This just makes it easier
+  # to manage difference instances using different versions of haproxy.
+  # If you have an instance called "foo", you know "haproxy-foo"
+  # is the binary.
+  $haproxy_link = "${bindir}/haproxy-${title}"
+  if $haproxy_package == 'haproxy' {
+    $haproxy_target = '/usr/sbin/haproxy'
+  } else {
+    $haproxy_target = "/opt/${haproxy_package}/sbin/haproxy"
+  }
+  file { $haproxy_link:
+    ensure => link,
+    target => $haproxy_target,
+  }
+
+  # Create an init.d file so that "service haproxy-$instance start" works.
+  # This is not required if the standard instance is being used.
+  if ($title == 'haproxy') or ($haproxy_package == 'haproxy') {
+  } else {
+    # TODO(tlim): Works for CentOS7 but should be reworked to use systemd.
+    $initfile = "/etc/init.d/haproxy-${title}"
+    file { $initfile:
+      ensure => file,
+      mode   => '0744',
+      owner  => 'root',
+      group  => 'root',
+      source => "puppet:///modules/${module_name}/haproxy.init",
+    }
+    File[$haproxy_link] -> File[$initfile]
+  }
+
+  Package[$haproxy_package] -> File[$bindir] -> File[$haproxy_link]
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,12 @@ class haproxy::params {
         ],
         'maxconn' => '8000'
       }
+      # Single instance:
+      $config_dir       = '/etc/haproxy'
       $config_file      = '/etc/haproxy/haproxy.cfg'
+      # Multi-instance:
+      $config_dir_tmpl  = '/etc/<%= @instance_name %>'
+      $config_file_tmpl = "${config_dir_tmpl}/<%= @instance_name %>.cfg"
     }
     'FreeBSD': {
       $package_name     = 'haproxy'
@@ -61,8 +66,16 @@ class haproxy::params {
         'clitimeout' => '50000',
         'srvtimeout' => '50000',
       }
+      # Single instance:
+      $config_dir       = '/usr/local/etc'
       $config_file      = '/usr/local/etc/haproxy.conf'
+      # Multi-instance:
+      $config_dir_tmpl  = '/usr/local/etc/<%= @instance_name %>'
+      $config_file_tmpl = "${config_dir_tmpl}/<%= @instance_name %>.conf"
     }
     default: { fail("The ${::osfamily} operating system is not supported with the haproxy module") }
   }
 }
+
+# TODO: test that the $config_file generated for FreeBSD instances
+#  and RedHat instances is as expected.

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -1,16 +1,30 @@
+#
 define haproxy::peer (
   $peers_name,
   $port,
   $ensure       = 'present',
   $server_names = $::hostname,
   $ipaddresses  = $::ipaddress,
+  $instance = 'haproxy',
 ) {
 
-  # Templats uses $ipaddresses, $server_name, $ports, $option
-  concat::fragment { "peers-${peers_name}-${name}":
-    order   => "30-peers-01-${peers_name}-${name}",
+  # We derive these settings so that the caller only has to specify $instance.
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    #$config_dir = $haproxy::params::config_dir
+    $config_file = $haproxy::params::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    #$config_dir = inline_template($haproxy::params::config_dir_tmpl)
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
+  # Templates uses $ipaddresses, $server_name, $ports, $option
+  concat::fragment { "${instance_name}-peers-${peers_name}-${name}":
     ensure  => $ensure,
-    target  => '/etc/haproxy/haproxy.cfg',
+    order   => "30-peers-01-${peers_name}-${name}",
+    target  => $config_file,
     content => template('haproxy/haproxy_peer.erb'),
   }
 }

--- a/manifests/peers.pp
+++ b/manifests/peers.pp
@@ -1,11 +1,25 @@
+#
 define haproxy::peers (
   $collect_exported = true,
+  $instance = 'haproxy',
 ) {
 
+  # We derive these settings so that the caller only has to specify $instance.
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    #$config_dir = $haproxy::params::config_dir
+    $config_file = $haproxy::params::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    #$config_dir = inline_template($haproxy::params::config_dir_tmpl)
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
   # Template uses: $name, $ipaddress, $ports, $options
-  concat::fragment { "${name}_peers_block":
+  concat::fragment { "${instance_name}-${name}_peers_block":
     order   => "30-peers-00-${name}",
-    target  => '/etc/haproxy/haproxy.cfg',
+    target  => $config_file,
     content => template('haproxy/haproxy_peers_block.erb'),
   }
 

--- a/manifests/userlist.pp
+++ b/manifests/userlist.pp
@@ -30,12 +30,25 @@
 define haproxy::userlist (
   $users = undef,
   $groups = undef,
+  $instance = 'haproxy',
 ) {
 
-  # Template usse $name, $users, $groups
-  concat::fragment { "${name}_userlist_block":
+  # We derive these settings so that the caller only has to specify $instance.
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    #$config_dir = $haproxy::params::config_dir
+    $config_file = $haproxy::params::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    #$config_dir = inline_template($haproxy::params::config_dir_tmpl)
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
+  # Template uses $name, $users, $groups
+  concat::fragment { "${instance_name}-${name}_userlist_block":
     order   => "12-${name}-00",
-    target  => $::haproxy::config_file,
+    target  => $config_file,
     content => template('haproxy/haproxy_userlist_block.erb'),
   }
 }

--- a/spec/defines/backend_spec.rb
+++ b/spec/defines/backend_spec.rb
@@ -13,10 +13,10 @@ describe 'haproxy::backend' do
   context "when no options are passed" do
     let(:title) { 'bar' }
 
-    it { should contain_concat__fragment('bar_backend_block').with(
+    it { should contain_concat__fragment('haproxy-bar_backend_block').with(
       'order'   => '20-bar-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nbackend bar\n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nbackend bar\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
 

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -22,7 +22,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server dero 1.1.1.1:18140 check\n"
@@ -39,7 +39,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'ensure'  => 'absent',
@@ -57,7 +57,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server dero 1.1.1.1:18140 check close\n"
@@ -75,7 +75,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server dero 1.1.1.1:18140 cookie dero check close\n"
@@ -93,7 +93,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server server01 192.168.56.200:18140 check\n  server server02 192.168.56.201:18140 check\n"
@@ -111,7 +111,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server server01 192.168.56.200:18140 check\n  server server01 192.168.56.200:18150 check\n  server server02 192.168.56.201:18140 check\n  server server02 192.168.56.201:18150 check\n"
@@ -128,7 +128,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server server01 192.168.56.200 check\n  server server02 192.168.56.201 check\n"

--- a/spec/defines/frontend_spec.rb
+++ b/spec/defines/frontend_spec.rb
@@ -19,10 +19,10 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('croy_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-croy_frontend_block').with(
       'order'   => '15-croy-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend croy\n  bind 1.1.1.1:18140 \n  option  tcplog\n"
+      'content' => "\nfrontend croy\n  bind 1.1.1.1:18140 \n  option tcplog\n"
     ) }
   end
   # C9948 C9947
@@ -38,10 +38,10 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option  tcplog\n"
+      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option tcplog\n"
     ) }
   end
   # C9948
@@ -54,10 +54,10 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option  tcplog\n"
+      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option tcplog\n"
     ) }
   end
   # C9971
@@ -70,10 +70,10 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  option  tcplog\n"
+      'content' => "\nfrontend apache\n  option tcplog\n"
     ) }
   end
   # C9972
@@ -141,10 +141,10 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.24:80 \n  option  tcplog\n"
+      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.24:80 \n  option tcplog\n"
     ) }
   end
   context "when bind options are provided" do
@@ -157,10 +157,10 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  bind 1.1.1.1:80 the options go here\n  bind 1.1.1.1:8080 the options go here\n  option  tcplog\n"
+      'content' => "\nfrontend apache\n  bind 1.1.1.1:80 the options go here\n  bind 1.1.1.1:8080 the options go here\n  option tcplog\n"
     ) }
   end
   context "when a comma-separated list of ports is provided" do
@@ -172,10 +172,10 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option  tcplog\n"
+      'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option tcplog\n"
     ) }
   end
 
@@ -186,10 +186,10 @@ describe 'haproxy::frontend' do
         :bind  => {'1.1.1.1:80' => []},
       }
     end
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  bind 1.1.1.1:80 \n  option  tcplog\n"
+      'content' => "\nfrontend apache\n  bind 1.1.1.1:80 \n  option tcplog\n"
     ) }
   end
 
@@ -206,10 +206,10 @@ describe 'haproxy::frontend' do
         },
       }
     end
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  option  tcplog\n"
+      'content' => "\nfrontend apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  option tcplog\n"
     ) }
   end
 

--- a/spec/defines/instance_service_spec.rb
+++ b/spec/defines/instance_service_spec.rb
@@ -1,0 +1,151 @@
+require 'spec_helper'
+
+describe 'haproxy::instance_service' do
+  let(:default_facts) do
+    {
+      :concat_basedir => '/dne',
+      :ipaddress      => '10.10.10.10'
+    }
+  end
+
+  context 'on any platform' do
+
+    # haproxy::instance 'haproxy' with defaults
+
+    context 'with title haproxy and defaults params' do
+      let(:title) { 'haproxy' }
+      it 'should install the haproxy package' do
+        subject.should contain_package('haproxy').with(
+          'ensure' => 'present'
+        )
+      end
+      it 'should create the exec directory' do
+        subject.should contain_file('/opt/haproxy').with(
+          'ensure' => 'directory',
+          'owner'  => 'root',
+          'group'  => 'root',
+          'mode'   => '0744'
+        )
+      end
+      it 'should create a link to the exec' do
+        subject.should contain_file('/opt/haproxy/haproxy-haproxy').with(
+          'ensure' => 'link',
+          'target' => '/usr/sbin/haproxy'
+        )
+      end
+      it 'should not create an init.d file' do
+        subject.should_not contain_file('/etc/init.d/haproxy-haproxy').with(
+          'ensure' => 'file'
+        )
+      end
+    end
+
+  # haproxy::instance 'haproxy' with custom settings
+
+  context 'with title group1 and defaults params' do
+    let(:title) { 'haproxy' }
+    let(:params) do
+      {
+        'haproxy_package' => 'customhaproxy',
+        'bindir' => '/weird/place'
+      }
+    end
+    it 'should install the customhaproxy package' do
+      subject.should contain_package('customhaproxy').with(
+        'ensure' => 'present'
+      )
+    end
+    it 'should create the exec directory' do
+      subject.should contain_file('/weird/place').with(
+        'ensure' => 'directory',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0744'
+      )
+    end
+    it 'should create a link to the exec' do
+      subject.should contain_file('/weird/place/haproxy-haproxy').with(
+        'ensure' => 'link',
+        'target' => '/opt/customhaproxy/sbin/haproxy'
+      )
+    end
+    it 'should not create an init.d file' do
+      subject.should_not contain_file('/etc/init.d/haproxy-haproxy').with(
+        'ensure' => 'file'
+      )
+    end
+    it 'should not manage the default init.d file' do
+      subject.should_not contain_file('/etc/init.d/haproxy').with(
+        'ensure' => 'file'
+      )
+    end
+  end
+
+  # haproxy::instance 'group1' with defaults
+
+    context 'with title group1 and defaults params' do
+      let(:title) { 'group1' }
+      it 'should install the haproxy package' do
+        subject.should contain_package('haproxy').with(
+          'ensure' => 'present'
+        )
+      end
+      it 'should create the exec directory' do
+        subject.should contain_file('/opt/haproxy').with(
+          'ensure' => 'directory',
+          'owner'  => 'root',
+          'group'  => 'root',
+          'mode'   => '0744'
+        )
+      end
+      it 'should create a link to the exec' do
+        subject.should contain_file('/opt/haproxy/haproxy-group1').with(
+          'ensure' => 'link',
+          'target' => '/usr/sbin/haproxy'
+        )
+      end
+      it 'should not create an init.d file' do
+        subject.should_not contain_file('/etc/init.d/haproxy-haproxy').with(
+          'ensure' => 'file'
+        )
+      end
+    end
+  end
+
+  # haproxy::instance 'group1' with custom settings
+
+  context 'with title group1 and defaults params' do
+    let(:title) { 'group1' }
+    let(:params) do
+      {
+        'haproxy_package' => 'customhaproxy',
+        'bindir'          => '/weird/place'
+      }
+    end
+    it 'should install the customhaproxy package' do
+      subject.should contain_package('customhaproxy').with(
+        'ensure' => 'present'
+      )
+    end
+    it 'should create the exec directory' do
+      subject.should contain_file('/weird/place').with(
+        'ensure' => 'directory',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0744'
+      )
+    end
+    it 'should create a link to the exec' do
+      subject.should contain_file('/weird/place/haproxy-group1').with(
+        'ensure' => 'link',
+        'target' => '/opt/customhaproxy/sbin/haproxy'
+      )
+    end
+    it 'should create an init.d file' do
+      subject.should contain_file('/etc/init.d/haproxy-group1').with(
+        'ensure' => 'file'
+      )
+    end
+  end
+
+end

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -1,13 +1,17 @@
 require 'spec_helper'
 
-describe 'haproxy', :type => :class do
+describe 'haproxy::instance' do
   let(:default_facts) do
     {
       :concat_basedir => '/dne',
       :ipaddress      => '10.10.10.10'
     }
   end
+
+  # haproxy::instance with service name "haproxy".
+
   context 'on supported platforms' do
+    let(:title) { 'haproxy' }
     describe 'for OS-agnostic configuration' do
       ['Debian', 'RedHat', 'Archlinux', 'FreeBSD',].each do |osfamily|
         context "on #{osfamily} family operatingsystems" do
@@ -18,6 +22,7 @@ describe 'haproxy', :type => :class do
             {
               'service_ensure' => 'running',
               'package_ensure' => 'present',
+              'package_name'   => 'haproxy',
               'service_manage' => true
             }
           end
@@ -117,6 +122,7 @@ describe 'haproxy', :type => :class do
             {
               'service_ensure' => true,
               'package_ensure' => 'present',
+              'package_name'   => 'haproxy',
               'service_manage' => false
             }
           end
@@ -194,8 +200,211 @@ describe 'haproxy', :type => :class do
         end
       end
     end
+  end
+
+  # haproxy::instance with 2nd instance and with non-standard service name.
+
+  context 'on supported platforms' do
+    let(:title) { 'group1' }
+    describe 'for OS-agnostic configuration' do
+      ['Debian', 'RedHat', 'Archlinux', 'FreeBSD',].each do |osfamily|
+        context "on #{osfamily} family operatingsystems" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'service_ensure' => 'running',
+              'package_ensure' => 'present',
+              'package_name'   => 'customhaproxy',
+              'service_manage' => true
+            }
+          end
+          it 'should install the customhaproxy package' do
+            subject.should contain_package('customhaproxy').with(
+              'ensure' => 'present'
+            )
+          end
+          it 'should install the customhaproxy service' do
+            subject.should contain_service('haproxy-group1').with(
+              'ensure'     => 'running',
+              'enable'     => 'true',
+              'hasrestart' => 'true',
+              'hasstatus'  => 'true'
+            )
+          end
+          it 'should not install the haproxy package' do
+            subject.should_not contain_package('haproxy')
+          end
+          it 'should not install the haproxy service' do
+            subject.should_not contain_service('haproxy')
+          end
+        end
+        # C9938
+        context "on #{osfamily} when specifying custom content" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            { 'custom_fragment' => "listen stats :9090\n  mode http\n  stats uri /\n  stats auth puppet:puppet\n" }
+          end
+          it 'should set the haproxy-group1 package' do
+            subject.should contain_concat__fragment('haproxy-group1-haproxy-base').with_content(
+              /listen stats :9090\n  mode http\n  stats uri \/\n  stats auth puppet:puppet\n/
+            )
+          end
+        end
+      end
+    end
+
+    describe 'for linux operating systems' do
+      ['Debian', 'RedHat', 'Archlinux', ].each do |osfamily|
+        context "on #{osfamily} family operatingsystems" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          it 'should set up /etc/haproxy-group1/haproxy-group1.cfg as a concat resource' do
+            subject.should contain_concat('/etc/haproxy-group1/haproxy-group1.cfg').with(
+              'owner' => '0',
+              'group' => '0',
+              'mode'  => '0644'
+            )
+          end
+          it 'should manage the chroot directory' do
+            subject.should contain_file('/var/lib/haproxy').with(
+              'ensure' => 'directory',
+              'owner'  => 'haproxy',
+              'group'  => 'haproxy'
+            )
+          end
+          it 'should contain a header concat fragment' do
+            subject.should contain_concat__fragment('haproxy-group1-00-header').with(
+              'target'  => '/etc/haproxy-group1/haproxy-group1.cfg',
+              'order'   => '01',
+              'content' => "# This file managed by Puppet\n"
+            )
+          end
+          it 'should contain a haproxy-group1-haproxy-base concat fragment' do
+            subject.should contain_concat__fragment('haproxy-group1-haproxy-base').with(
+              'target'  => '/etc/haproxy-group1/haproxy-group1.cfg',
+              'order'   => '10'
+            )
+          end
+          describe 'Base concat fragment contents' do
+            let(:contents) { param_value(subject, 'concat::fragment', 'haproxy-group1-haproxy-base', 'content').split("\n") }
+            # C9936 C9937
+            it 'should contain global and defaults sections' do
+              contents.should include('global')
+              contents.should include('defaults')
+            end
+            it 'should log to an ip address for local0' do
+              contents.should be_any { |match| match =~ /  log  \d+(\.\d+){3} local0/ }
+            end
+            it 'should specify the default chroot' do
+              contents.should include('  chroot  /var/lib/haproxy')
+            end
+            it 'should specify the correct user' do
+              contents.should include('  user  haproxy')
+            end
+            it 'should specify the correct group' do
+              contents.should include('  group  haproxy')
+            end
+            it 'should specify the correct pidfile' do
+              contents.should include('  pidfile  /var/run/haproxy.pid')
+            end
+          end
+        end
+        context "on #{osfamily} family operatingsystems without managing the service" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'service_ensure' => true,
+              'package_ensure' => 'present',
+              'package_name'   => 'customhaproxy',
+              'service_manage' => false
+            }
+          end
+          it 'should install the customhaproxy package' do
+            subject.should contain_package('customhaproxy').with(
+              'ensure' => 'present'
+            )
+          end
+          it 'should not manage the customhaproxy service' do
+            subject.should_not contain_service('haproxy-group1')
+          end
+          it 'should set up /etc/haproxy-group1/haproxy-group1.cfg as a concat resource' do
+            subject.should contain_concat('/etc/haproxy-group1/haproxy-group1.cfg').with(
+              'owner' => '0',
+              'group' => '0',
+              'mode'  => '0644'
+            )
+          end
+          it 'should manage the chroot directory' do
+            subject.should contain_file('/var/lib/haproxy').with(
+              'ensure' => 'directory'
+            )
+          end
+          it 'should contain a header concat fragment' do
+            subject.should contain_concat__fragment('haproxy-group1-00-header').with(
+              'target'  => '/etc/haproxy-group1/haproxy-group1.cfg',
+              'order'   => '01',
+              'content' => "# This file managed by Puppet\n"
+            )
+          end
+          it 'should contain a haproxy-group1-haproxy-base concat fragment' do
+            subject.should contain_concat__fragment('haproxy-group1-haproxy-base').with(
+              'target'  => '/etc/haproxy-group1/haproxy-group1.cfg',
+              'order'   => '10'
+            )
+          end
+          describe 'Base concat fragment contents' do
+            let(:contents) { param_value(subject, 'concat::fragment', 'haproxy-group1-haproxy-base', 'content').split("\n") }
+            it 'should contain global and defaults sections' do
+              contents.should include('global')
+              contents.should include('defaults')
+            end
+            it 'should log to an ip address for local0' do
+              contents.should be_any { |match| match =~ /  log  \d+(\.\d+){3} local0/ }
+            end
+            it 'should specify the default chroot' do
+              contents.should include('  chroot  /var/lib/haproxy')
+            end
+            it 'should specify the correct user' do
+              contents.should include('  user  haproxy')
+            end
+            it 'should specify the correct group' do
+              contents.should include('  group  haproxy')
+            end
+            it 'should specify the correct pidfile' do
+              contents.should include('  pidfile  /var/run/haproxy.pid')
+            end
+          end
+        end
+        context "on #{osfamily} when specifying a restart_command" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'restart_command' => '/etc/init.d/haproxy-group1 reload',
+              'service_manage'  => true
+            }
+          end
+          it 'should set the customhaproxy package' do
+            subject.should contain_service('haproxy-group1').with(
+              'restart' => '/etc/init.d/haproxy-group1 reload'
+            )
+          end
+        end
+      end
+    end
+
+    # FreeBSD: haproxy::instance with service name "haproxy".
 
     describe 'for freebsd' do
+      let(:title) { 'haproxy' }
       context "on freebsd family operatingsystems" do
         let(:facts) do
           { :osfamily => 'FreeBSD' }.merge default_facts
@@ -251,6 +460,7 @@ describe 'haproxy', :type => :class do
           {
             'service_ensure' => true,
             'package_ensure' => 'present',
+            'package_name'   => 'haproxy',
             'service_manage' => false
           }
         end
@@ -322,14 +532,16 @@ describe 'haproxy', :type => :class do
       end
     end
 
+    # OS-specific configurations:
+
     describe 'for OS-specific configuration' do
       context 'only on Debian family operatingsystems' do
         let(:facts) do
           { :osfamily => 'Debian' }.merge default_facts
         end
         it 'should manage haproxy service defaults' do
-          subject.should contain_file('/etc/default/haproxy')
-          verify_contents(subject, '/etc/default/haproxy', ['ENABLED=1'])
+          subject.should contain_file('/etc/default/haproxy-group1')
+          verify_contents(subject, '/etc/default/haproxy-group1', ['ENABLED=1'])
         end
       end
       context 'only on RedHat family operatingsystems' do
@@ -340,7 +552,10 @@ describe 'haproxy', :type => :class do
     end
   end
 
+  # Unsupported OSs:
+
   context 'on unsupported operatingsystems' do
+    let(:title) { 'haproxy' }
     let(:facts) do
       { :osfamily => 'windows' }.merge default_facts
     end

--- a/spec/defines/listen_spec.rb
+++ b/spec/defines/listen_spec.rb
@@ -19,10 +19,10 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('croy_listen_block').with(
+    it { should contain_concat__fragment('haproxy-croy_listen_block').with(
       'order'   => '20-croy-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten croy\n  bind 1.1.1.1:18140 \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nlisten croy\n  bind 1.1.1.1:18140 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
   # C9940
@@ -38,10 +38,10 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
   # C9940
@@ -54,10 +54,10 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
   # C9962
@@ -70,10 +70,10 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
   # C9963
@@ -114,10 +114,10 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind some-hostname:80 \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind some-hostname:80 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
   context "when a * is passed for ip address" do
@@ -129,10 +129,10 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind *:80 \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind *:80 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
   context "when a bind parameter hash is passed" do
@@ -144,10 +144,10 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind 10.0.0.1:333 ssl crt public.puppetlabs.com\n  bind 192.168.122.1:8082 \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind 10.0.0.1:333 ssl crt public.puppetlabs.com\n  bind 192.168.122.1:8082 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
   context "when a ports parameter and a bind parameter are passed" do
@@ -201,10 +201,10 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind 1.1.1.1:80 the options go here\n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind 1.1.1.1:80 the options go here\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
   context "when bind parameter is used without ipaddress parameter" do
@@ -215,10 +215,10 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind 1.1.1.1:80 \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind 1.1.1.1:80 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
 
@@ -235,10 +235,10 @@ describe 'haproxy::listen' do
         },
       }
     end
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  balance  roundrobin\n  option  tcplog\n  option  ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
 

--- a/spec/defines/peer_spec.rb
+++ b/spec/defines/peer_spec.rb
@@ -4,8 +4,10 @@ describe 'haproxy::peer' do
   let(:title) { 'dero' }
   let(:facts) do
     {
-      :ipaddress => '1.1.1.1',
-      :hostname  => 'dero',
+      :ipaddress      => '1.1.1.1',
+      :hostname       => 'dero',
+      :osfamily       => 'Redhat',
+      :concat_basedir => '/dne',
     }
   end
 
@@ -17,7 +19,7 @@ describe 'haproxy::peer' do
       }
     end
 
-    it { should contain_concat__fragment('peers-tyler-dero').with(
+    it { should contain_concat__fragment('haproxy-peers-tyler-dero').with(
       'order'   => '30-peers-01-tyler-dero',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  peer dero 1.1.1.1:1024\n"
@@ -33,7 +35,7 @@ describe 'haproxy::peer' do
       }
     end
 
-    it { should contain_concat__fragment('peers-tyler-dero').with(
+    it { should contain_concat__fragment('haproxy-peers-tyler-dero').with(
       'ensure' => 'absent'
     ) }
   end

--- a/spec/defines/peers_spec.rb
+++ b/spec/defines/peers_spec.rb
@@ -1,12 +1,16 @@
 require 'spec_helper'
 
 describe 'haproxy::peers' do
-  let(:facts) {{ :ipaddress => '1.1.1.1' }}
+  let(:facts) {{
+    :ipaddress      => '1.1.1.1',
+    :osfamily       => 'Redhat',
+    :concat_basedir => '/dne',
+  }}
 
   context "when no options are passed" do
     let(:title) { 'bar' }
 
-    it { should contain_concat__fragment('bar_peers_block').with(
+    it { should contain_concat__fragment('haproxy-bar_peers_block').with(
       'order'   => '30-peers-00-bar',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\npeers bar\n"

--- a/spec/defines/userlist_spec.rb
+++ b/spec/defines/userlist_spec.rb
@@ -26,7 +26,7 @@ describe 'haproxy::userlist' do
       }
     end
 
-    it { should contain_concat__fragment('admins_userlist_block').with(
+    it { should contain_concat__fragment('haproxy-admins_userlist_block').with(
       'order'   => '12-admins-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nuserlist admins\n  group superadmins users kitchen scott\n  group megaadmins users kitchen\n  user scott insecure-password elgato\n  user kitchen insecure-password foobar\n"

--- a/templates/fragments/_mode.erb
+++ b/templates/fragments/_mode.erb
@@ -1,3 +1,3 @@
 <% if @mode -%>
-  mode  <%= @mode %>
+  mode <%= @mode %>
 <% end -%>

--- a/templates/fragments/_options.erb
+++ b/templates/fragments/_options.erb
@@ -1,5 +1,5 @@
 <% @options.sort.each do |key, val| -%>
 <% Array(val).each do |item| -%>
-  <%= key %>  <%= item %>
+  <%= key %> <%= item %>
 <% end -%>
 <% end -%>

--- a/templates/haproxy-base.cfg.erb
+++ b/templates/haproxy-base.cfg.erb
@@ -19,7 +19,7 @@ defaults
   <%= key %>  <%= val %>
 <% end -%>
 <% end -%>
-<% if @custom_fragment -%>
+<% if @_custom_fragment -%>
 
-<%= @custom_fragment %>
+<%= @_custom_fragment %>
 <% end -%>


### PR DESCRIPTION
...on a host.  See [MODULES-1783]

  * New Define Resource Type: haproxy::instance
  * Class[haproxy] is now a wrapper that calls haproxy::instance
  * Add "instance" parameter to all public defines.
  * All private classes become private defined resource types.
  * Pass parameters to private defined resource types rather than
  * "inherts params"
  * Documentation updated.