### PR TITLE
Set ipaddress undef by default

### DIFF
--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -77,7 +77,7 @@
 #
 define haproxy::listen (
   $ports                        = undef,
-  $ipaddress                    = [$::ipaddress],
+  $ipaddress                    = undef,
   $bind                         = undef,
   $mode                         = undef,
   $collect_exported             = true,


### PR DESCRIPTION
Otherwise you will always get this error when using bind...
```Error: Could not retrieve catalog from remote server: Error 400 on SERVER: The use of $ipaddress and $bind is mutually exclusive, please choose either one at /modules/haproxy/manifests/listen.pp:99```

... unless you set **ipaddress => ""**, on your manifest, which does not make sense to me.