### PR TITLE
Add haproxy::instance for the creation of multiple instances of haproxy

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
       ref: '1.2.3'
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: '2.4.0'
+      ref: '3.2.0'
   symlinks:
     haproxy: "#{source_dir}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2015-07-15 - Supported Release 1.3.0
+### Summary
+This release adds puppet 4 support, and adds the ability to specify the order
+of option entries for `haproxy::frontend` and `haproxy::listen` defined
+resources.
+
+#### Features
+- Adds puppet 4 compatibility
+- Updated readme
+- Gentoo compatibility
+- Suse compatibility
+- Add ability for frontend and listen to be ordered
+
+
 ##2015-03-10 - Supported Release 1.2.0
 ###Summary
 This release adds flexibility for configuration of balancermembers and bind settings, and adds support for configuring peers. This release also renames the `tests` directory to `examples`

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :system_tests do
     gem 'beaker-rspec',  :require => false
   end
   gem 'serverspec',    :require => false
+  gem 'beaker-puppet_install_helper', :require => false
 end
 
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     * [Configure a load balancer with exported resources](#configure-a-load-balancer-with-exported-resources)
     * [Set up a frontend service](#set-up-a-frontend-service)
     * [Set up a backend service](#set-up-a-backend-service)
+    * [Configure multiple haproxy instances on one machine](#configure-multiple-haproxy-instances-on-one-machine)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 6. [Limitations - OS compatibility, etc.](#limitations)
 7. [Development - Guide for contributing to the module](#development)
@@ -78,7 +79,9 @@ class { 'haproxy':
   defaults_options => {
     'log'     => 'global',
     'stats'   => 'enable',
-    'option'  => 'redispatch',
+    'option'  => [
+      'redispatch',
+    ],
     'retries' => '3',
     'timeout' => [
       'http-request 10s',
@@ -89,6 +92,36 @@ class { 'haproxy':
       'check 10s',
     ],
     'maxconn' => '8000',
+  },
+}
+~~~
+
+The above shown values are the module's defaults for platforms like Debian and RedHat (see `haproxy::params` for details). If you wish to override or add to any of these defaults set `merge_options => true` (see below) and set `global_options` and/or `defaults_options` to a hash containing just the `option => value` pairs you need changed or added. In case of duplicates your supplied values will "win" over the default values (this is especially noteworthy for arrays -- they cannot be merged easily). If you want to completely remove a parameter set it to the special value `undef`:
+
+~~~puppet
+class { 'haproxy':
+  global_options   => {
+    'maxconn' => undef,
+    'user'    => 'root',
+    'group'   => 'root',
+    'stats'   => [
+      'socket /var/lib/haproxy/stats',
+      'timeout 30s'
+    ]
+  },
+  defaults_options => {
+    'retries' => '5',
+    'option'  => [
+      'redispatch',
+      'http-server-close',
+      'logasap',
+    ],
+    'timeout' => [
+      'http-request 7s',
+      'connect 3s',
+      'check 9s',
+    ],
+    'maxconn' => '15000',
   },
 }
 ~~~
@@ -209,7 +242,7 @@ haproxy::frontend { 'puppet00':
   bind_options  => 'accept-proxy',
   options       => {
     'default_backend' => 'puppet_backend00',
-    'timeout client'  => '30',
+    'timeout client'  => '30s',
     'option'          => [
       'tcplog',
       'accept-invalid-http-request',
@@ -228,7 +261,7 @@ haproxy::frontend { 'puppet00':
   bind_options  => 'accept-proxy',
   options       => [
     { 'default_backend' => 'puppet_backend00' },
-    { 'timeout client'  => '30' },
+    { 'timeout client'  => '30s' },
     { 'option'          => [
         'tcplog',
         'accept-invalid-http-request',
@@ -272,6 +305,83 @@ haproxy::backend { 'puppet00':
 
 This adds the backend options to the configuration block in the same order as they appear within the array.
 
+###Configure multiple haproxy instances on one machine
+
+This is an advanced feature typically only used at large sites.
+
+It is possible to run multiple haproxy processes ("instances") on the
+same machine. This has the benefit that each is a distinct failure domain,
+each can be restarted independently, and each can run a different binary.
+
+In this use case, instead of using `Class['haproxy']`, each process
+is started using `haproxy::instance{'inst'}` where `inst` is the
+name of the instance.  It assumes there is a matching `Service['inst']`
+that will be used to manage service.  Different sites may have
+different requirements for how the `Service[]` is constructed.
+However, `haproxy::instance_service` exists as an example of one
+way to do this, and may be sufficient for most sites.
+
+In this example, two instances are created. The first uses the standard
+class and uses `haproxy::instance` to add an additional instance called
+`beta`.
+
+~~~puppet
+   class{ 'haproxy': }
+   haproxy::listen { 'puppet00':
+     instance         => 'haproxy',
+     collect_exported => false,
+     ipaddress        => $::ipaddress,
+     ports            => '8800',
+   }
+
+   haproxy::instance { 'beta': }
+   ->
+   haproxy::instance_service { 'beta':
+     haproxy_package     => 'custom_haproxy',
+     haproxy_init_source => "puppet:///modules/${module_name}/haproxy-beta.init",
+   }
+   ->
+   haproxy::listen { 'puppet00':
+     instance         => 'beta',
+     collect_exported => false,
+     ipaddress        => $::ipaddress,
+     ports            => '9900',
+   }
+~~~
+
+In this example, two instances are created called `group1` and `group2`.
+The second uses a custom package.
+
+~~~puppet
+   haproxy::instance { 'group1': }
+   ->
+   haproxy::instance_service { 'group1':
+     haproxy_init_source => "puppet:///modules/${module_name}/haproxy-group1.init",
+   }
+   ->
+   haproxy::listen { 'group1-puppet00':
+     section_name     => 'puppet00',
+     instance         => 'group1',
+     collect_exported => false,
+     ipaddress        => $::ipaddress,
+     ports            => '8800',
+   }
+   haproxy::instance { 'group2': }
+   ->
+   haproxy::instance_service { 'group2':
+     haproxy_package     => 'custom_haproxy',
+     haproxy_init_source => "puppet:///modules/${module_name}/haproxy-group2.init",
+   }
+   ->
+   haproxy::listen { 'group2-puppet00':
+     section_name     => 'puppet00',
+     instance         => 'group2',
+     collect_exported => false,
+     ipaddress        => $::ipaddress,
+     ports            => '9900',
+   }
+~~~
+
 ##Reference
 
 ###Classes
@@ -298,6 +408,8 @@ This adds the backend options to the configuration block in the same order as th
 * [`haproxy::userlist`](#define-haproxyuserlist): Creates a userlist entry in haproxy.cfg.
 * [`haproxy::peers`](#define-haproxypeers): Creates a peers entry in haproxy.cfg.
 * [`haproxy::peer`](#define-haproxypeer): Creates server entries within a peers entry in haproxy.cfg.
+* [`haproxy::instance`](#define-instance): Creates multiple instances of haproxy on the same machine.
+* [`haproxy::instance_service`](#define-instanceservice): Example of one way to prepare environment for haproxy::instance.
 
 ####Private defines
 
@@ -314,38 +426,74 @@ Main class, includes all other classes.
 
 * `defaults_options`: Configures all the default HAProxy options at once. Valid options: a hash of `option => value` pairs. To set an option multiple times (e.g. multiple 'timeout' or 'stats' values) pass its value as an array. Each element in your array results in a separate instance of the option, on a separate line in haproxy.cfg. Default:
 
-~~~puppet
-{
-        'log'     => 'global',
-        'stats'   => 'enable',
-        'option'  => 'redispatch',
-        'retries' => '3',
-        'timeout' => [
-          'http-request 10s',
-          'queue 1m',
-          'connect 10s',
-          'client 1m',
-          'server 1m',
-          'check 10s',
-        ],
-        'maxconn' => '8000'
-}
-~~~
+  ~~~puppet
+  {
+          'log'     => 'global',
+          'stats'   => 'enable',
+          'option'  => [
+            'redispatch',
+          ],
+          'retries' => '3',
+          'timeout' => [
+            'http-request 10s',
+            'queue 1m',
+            'connect 10s',
+            'client 1m',
+            'server 1m',
+            'check 10s',
+          ],
+          'maxconn' => '8000'
+  }
+  ~~~
+
+  To override or add to any of these default values you don't have to recreate and supply the whole hash, just set `merge_options => true` (see below) and set `defaults_options` to a hash of the `option => value` pairs you'd like to override or add. But note that array values cannot be easily merged with the default values without potentially creating duplicates so you always have to supply the whole array yourself. And if you want a parameter to not appear at all in the resulting configuration set its value to `undef`. Example:
+
+  ~~~puppet
+  {
+          'retries' => '5',
+          'timeout' => [
+            'http-request 7s',
+	    'http-keep-alive 10s,
+            'queue 1m',
+            'connect 5s',
+            'client 1m',
+            'server 1m',
+            'check 10s',
+          ],
+          'maxconn' => undef,
+  }
+  ~~~
 
 * `global_options`: Configures all the global HAProxy options at once. Valid options: a hash of `option => value` pairs. To set an option multiple times (e.g. multiple 'timeout' or 'stats' values) pass its value as an array. Each element in your array results in a separate instance of the option, on a separate line in haproxy.cfg. Default:
 
-~~~puppet
-{
-        'log'     => "${::ipaddress} local0",
-        'chroot'  => '/var/lib/haproxy',
-        'pidfile' => '/var/run/haproxy.pid',
-        'maxconn' => '4000',
-        'user'    => 'haproxy',
-        'group'   => 'haproxy',
-        'daemon'  => '',
-        'stats'   => 'socket /var/lib/haproxy/stats'
-}
-~~~
+  ~~~puppet
+  {
+          'log'     => "${::ipaddress} local0",
+          'chroot'  => '/var/lib/haproxy',
+          'pidfile' => '/var/run/haproxy.pid',
+          'maxconn' => '4000',
+          'user'    => 'haproxy',
+          'group'   => 'haproxy',
+          'daemon'  => '',
+          'stats'   => 'socket /var/lib/haproxy/stats'
+  }
+  ~~~
+
+  To override or add to any of these default values you don't have to recreate and supply the whole hash, just set `merge_options => true` (see below) and set `global_options` to a hash of the `option => value` pairs you'd like to override or add. But note that array values cannot be easily merged with the default values without potentially creating duplicates so you always have to supply the whole array yourself. And if you want a parameter to not appear at all in the resulting configuration set its value to `undef`. Example:
+
+  ~~~puppet
+  {
+	  log     => undef,
+          'user'  => 'root',
+          'group' => 'root',
+          'stats' => [
+            'socket /var/lib/haproxy/admin.sock mode 660 level admin',
+            'timeout 30s',
+          ],
+  }
+  ~~~
+
+* `merge_options`: Whether to merge the user-supplied `global_options`/`defaults_options` hashes with their default values set in params.pp. Merging allows to change or add options without having to recreate the entire hash. Defaults to `false`, but will default to `true` in future releases.
 
 * `package_ensure`: Specifies whether the HAProxy package should exist. Defaults to 'present'. Valid options: 'present' and 'absent'. Default: 'present'.
 
@@ -356,6 +504,8 @@ Main class, includes all other classes.
 * `service_ensure`: Specifies whether the HAProxy service should be enabled at boot and running, or disabled at boot and stopped. Valid options: 'running' and 'stopped'. Default: 'running'.
 
 * `service_manage`: Specifies whether the state of the HAProxy service should be managed by Puppet. Valid options: 'true' and 'false'. Default: 'true'.
+
+* `service_options`: Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
 
 #### Define: `haproxy::balancermember`
 
@@ -377,6 +527,8 @@ Configures a service inside a listening or backend service configuration block i
 
 * `server_names`: *Required unless `collect_exported` is set to `true`.* Sets the name of the balancermember service in the listening service's configuration block in haproxy.cfg. Valid options: a string or an array. If you pass an array, it must contain the same number of elements as the array you pass to the `ipaddresses` parameter. For each pair of entries in the `ipaddresses` and `server_names` arrays, Puppet creates server entries in haproxy.cfg targeting each port specified in the `ports` parameter. Default: the value of the `$::hostname` fact.
 
+* `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
+
 #### Define: `haproxy::backend`
 
 Sets up a backend service configuration block inside haproxy.cfg. Each backend service needs one or more balancermember services (declared with the [`haproxy::balancermember` define](#define-haproxybalancermember)).
@@ -388,6 +540,8 @@ Sets up a backend service configuration block inside haproxy.cfg. Each backend s
 * `name`: *Optional.* Supplies a name for the backend service. This value appears right after the 'backend' statement in haproxy.cfg. Valid options: a string. Default: the title of your declared resource.
 
 * `options`: *Optional.* Adds one or more options to the backend service's configuration block in haproxy.cfg. Valid options: a hash or an array. To control the ordering of these options within the configuration block, supply an array of hashes where each hash contains one 'option => value' pair. Default:
+
+* `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
 
 ~~~puppet
 {
@@ -401,7 +555,7 @@ Sets up a backend service configuration block inside haproxy.cfg. Each backend s
 
 #### Define: `haproxy::frontend`
 
-Sets up a backend service configuration block inside haproxy.cfg. Each backend service needs one or more balancermember services (declared with the [`haproxy::balancermember` define](#define-haproxybalancermember)).
+Sets up a frontend service configuration block inside haproxy.cfg. Each frontend service needs one or more balancermember services (declared with the [`haproxy::balancermember` define](#define-haproxybalancermember)).
 
 ##### Parameters
 
@@ -427,7 +581,7 @@ For more information, see the [HAProxy Configuration Manual](http://cbonte.githu
 
 * `name`: *Optional.* Supplies a name for the frontend service. This value appears right after the 'frontend' statement in haproxy.cfg. Valid options: a string. Default: the title of your declared resource.
 
-* `options`: *Optional.* Adds one or more options to the frontend service's configuration block in haproxy.cfg. Valid options: a hash or an array. To control the ordering of these options within the configuration block, supply an array of hashes where each hash contains one 'option => value' pair. Default:
+* `options`: *Optional.* Adds one or more options to the frontend service's configuration block in haproxy.cfg. Valid options: a hash or an array. To control the ordering of these options within the configuration block, supply an array of hashes where each hash contains one 'option => value' pair.
 
 ~~~puppet
 {
@@ -438,6 +592,8 @@ For more information, see the [HAProxy Configuration Manual](http://cbonte.githu
 ~~~
 
 * `ports`: *Required unless `bind` is specified.* Specifies which ports to listen on for the address specified in `ipaddress`. Valid options: an array of port numbers and/or port ranges or a string containing a comma-delimited list of port numbers/ranges.
+
+* `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
 
 #### Define: `haproxy::listen`
 
@@ -473,6 +629,7 @@ For more information, see the [HAProxy Configuration Manual](http://cbonte.githu
 
 * `ports`: *Required unless `bind` is specified.* Specifies which ports to listen on for the address specified in `ipaddress`. Valid options: a single comma-delimited string or an array of strings. Each string can contain a port number or a hyphenated range of port numbers (e.g., 8443-8450).
 
+
 #### Define: `haproxy::userlist`
 
 Sets up a [userlist configuration block](http://cbonte.github.io/haproxy-dconv/configuration-1.4.html#3.4) inside haproxy.cfg.
@@ -481,9 +638,11 @@ Sets up a [userlist configuration block](http://cbonte.github.io/haproxy-dconv/c
 
 * `groups`: *Required unless `users` is specified.* Adds groups to the userlist. For more information, see the [HAProxy Configuration Manual](http://cbonte.github.io/haproxy-dconv/configuration-1.4.html#3.4-group). Valid options: an array of groupnames. Default: undef.
 
-* `name`: *Optional.* Supplies a name for the userlist. This value appears right after the 'listen' statement in haproxy.cfg. Valid options: a string. Default: the title of your declared resource.
+* `name`: *Optional.* Supplies a name for the userlist. This value appears right after the 'userlist' statement in haproxy.cfg. Valid options: a string. Default: the title of your declared resource.
 
 * `users`: *Required unless `groups` is specified.* Adds users to the userlist. For more information, see the [HAProxy Configuration Manual](http://cbonte.github.io/haproxy-dconv/configuration-1.4.html#3.4-user). Valid options: an array of usernames. Default: undef.
+
+* `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
 
 #### Define: `haproxy::peers`
 
@@ -494,6 +653,8 @@ Sets up a peers entry in haproxy.cfg on the load balancer. This entry is require
 * `collect_exported`: *Optional.* Specifies whether to collect resources exported by other nodes. This serves as a form of autodiscovery. Valid options: 'true' and 'false'. Default: 'true'.
 
 * `name`: *Optional.* Appends a name to the peers entry in haproxy.cfg. Valid options: a string. Default: the title of your declared resource.
+
+* `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
 
 #### Define: `haproxy::peer`
 
@@ -510,6 +671,88 @@ Sets up a peer entry inside the peers configuration block in haproxy.cfg.
 * `ports`: *Required.* Specifies the port on which the load balancer sends connections to peers. Valid options: a string containing a port number.
 
 * `server_names`: *Required unless the `collect_exported` parameter of your `haproxy::peers` resource is set to `true`.* Sets the name of the peer server as listed in the peers configuration block. Valid options: a string or an array. If you pass an array, it must contain the same number of elements as the array you pass to `ipaddresses`. Puppet pairs up the elements from both arrays and creates a peer for each pair of values. Default: the value of the `$::hostname` fact.
+
+* `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
+
+#### Define: `haproxy::instance`
+
+Runs multiple instances of haproxy on the same machine.  Normally users
+use the Class['haproxy'], which runs a single haproxy daemon on a machine.
+
+##### Parameters
+
+* `package_ensure`: Chooses whether the haproxy package should be installed or uninstalled.
+Defaults to 'present'
+
+* `package_name`:
+The package name of haproxy. Defaults to undef, and no package is installed.
+NOTE: Class['haproxy'] has a different default.
+
+* `service_ensure`:
+Chooses whether the haproxy service should be running & enabled at boot, or
+stopped and disabled at boot. Defaults to 'running'
+
+* `service_manage`:
+Chooses whether the haproxy service state should be managed by puppet at
+all. Defaults to true
+
+* `global_options`:
+A hash of all the haproxy global options. If you want to specify more
+than one option (i.e. multiple timeout or stats options), pass those
+options as an array and you will get a line for each of them in the
+resultant haproxy.cfg file.
+
+* `defaults_options`:
+A hash of all the haproxy defaults options. If you want to specify more
+than one option (i.e. multiple timeout or stats options), pass those
+options as an array and you will get a line for each of them in the
+resultant haproxy.cfg file.
+
+* `restart_command`:
+Command to use when restarting the on config changes.
+Passed directly as the <code>'restart'</code> parameter to the service
+resource.
+Defaults to undef i.e. whatever the service default is.
+
+* `custom_fragment`:
+Allows arbitrary HAProxy configuration to be passed through to support
+additional configuration not available via parameters, or to short-circuit
+the defined resources such as haproxy::listen when an operater would rather
+just write plain configuration. Accepts a string (ie, output from the
+template() function). Defaults to undef
+
+* `config_file`:
+Allows arbitrary config filename to be specified. If this is used,
+it is assumed that the directory path to the file exists and has
+owner/group/permissions as desired.  If set to undef, the name
+will be generated as follows:
+If $title is 'haproxy', the operating system default will be used.
+Otherwise, /etc/haproxy-$title/haproxy-$title.conf (Linux),
+or /usr/local/etc/haproxy-$title/haproxy-$title.conf (FreeBSD)
+The parent directory will be created automatically.
+Defaults to undef.
+
+#### Define: `haproxy::instance_service`
+
+Example manifest that shows one way to create the Service[] environment needed
+by haproxy::instance.
+
+##### Parameters
+
+* `haproxy_package`:
+The name of the package to be installed. This is useful if
+you package your own custom version of haproxy.
+Defaults to 'haproxy'
+
+* `bindir`:
+Where to put symlinks to the binary used for each instance.
+Defaults to '/opt/haproxy/bin'
+
+* `haproxy_init_source`:
+Path to the template init.d script that will start/restart/reload this instance.
+
+* `haproxy_unit_template`:
+Path to the template systemd service unit definition that will start/restart/reload this instance.
 
 ##Limitations
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,34 +1,66 @@
 # Private class
-class haproxy::config inherits haproxy {
+define haproxy::config (
+  $instance_name,
+  $config_file,
+  $global_options,
+  $defaults_options,
+  $config_dir = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
+  $custom_fragment = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
+  $merge_options = $haproxy::merge_options,
+) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  concat { $haproxy::config_file:
+  if $merge_options {
+    $_global_options   = merge($haproxy::params::global_options, $global_options)
+    $_defaults_options = merge($haproxy::params::defaults_options, $defaults_options)
+  } else {
+    $_global_options   = $global_options
+    $_defaults_options = $defaults_options
+    warning("${module_name}: The \$merge_options parameter will default to true in the next major release. Please review the documentation regarding the implications.")
+  }
+
+  if $config_dir != undef {
+    file { $config_dir:
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+    }
+  }
+
+  if $config_file != undef {
+    $_config_file = $config_file
+  } else {
+    $_config_file = $haproxy::config_file
+  }
+
+  concat { $_config_file:
     owner => '0',
     group => '0',
     mode  => '0644',
   }
 
   # Simple Header
-  concat::fragment { '00-header':
-    target  => $haproxy::config_file,
+  concat::fragment { "${instance_name}-00-header":
+    target  => $config_file,
     order   => '01',
     content => "# This file managed by Puppet\n",
   }
 
-  # Template uses $global_options, $defaults_options
-  concat::fragment { 'haproxy-base':
-    target  => $haproxy::config_file,
+  # Template uses $_global_options, $_defaults_options, $custom_fragment
+  concat::fragment { "${instance_name}-haproxy-base":
+    target  => $config_file,
     order   => '10',
-    content => template('haproxy/haproxy-base.cfg.erb'),
+    content => template("${module_name}/haproxy-base.cfg.erb"),
   }
 
-  if $haproxy::global_options['chroot'] {
-    file { $haproxy::global_options['chroot']:
+  if $_global_options['chroot'] {
+    file { $_global_options['chroot']:
       ensure => directory,
-      owner  => $haproxy::global_options['user'],
-      group  => $haproxy::global_options['group'],
+      owner  => $_global_options['user'],
+      group  => $_global_options['group'],
     }
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,14 +44,14 @@ define haproxy::config (
 
   # Simple Header
   concat::fragment { "${instance_name}-00-header":
-    target  => $config_file,
+    target  => $_config_file,
     order   => '01',
     content => "# This file managed by Puppet\n",
   }
 
   # Template uses $_global_options, $_defaults_options, $custom_fragment
   concat::fragment { "${instance_name}-haproxy-base":
-    target  => $config_file,
+    target  => $_config_file,
     order   => '10',
     content => template("${module_name}/haproxy-base.cfg.erb"),
   }

--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -11,9 +11,9 @@
 #
 # === Parameters
 #
-# [*name*]
-#   The namevar of the defined resource type is the frontend service's name.
+# [*section_name*]
 #    This name goes right after the 'frontend' statement in haproxy.cfg
+#    Default: $name (the namevar of the resource).
 #
 # [*ports*]
 #   Ports on which the proxy will listen for connections on the ip address
@@ -56,7 +56,7 @@
 #        'tcplog',
 #        'accept-invalid-http-request',
 #      ],
-#      'timeout client' => '30',
+#      'timeout client' => '30s',
 #      'balance'    => 'roundrobin'
 #    },
 #  }
@@ -76,10 +76,11 @@ define haproxy::frontend (
       'tcplog',
     ],
   },
+  $instance         = 'haproxy',
+  $section_name     = $name,
   # Deprecated
-  $bind_options     = '',
+  $bind_options     = undef,
 ) {
-
   if $ports and $bind {
     fail('The use of $ports and $bind is mutually exclusive, please choose either one')
   }
@@ -92,10 +93,20 @@ define haproxy::frontend (
   if $bind {
     validate_hash($bind)
   }
-  # Template uses: $name, $ipaddress, $ports, $options
-  concat::fragment { "${name}_frontend_block":
-    order   => "15-${name}-00",
-    target  => $::haproxy::config_file,
+
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $config_file = $haproxy::params::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
+  # Template uses: $section_name, $ipaddress, $ports, $options
+  concat::fragment { "${instance_name}-${section_name}_frontend_block":
+    order   => "15-${section_name}-00",
+    target  => $config_file,
     content => template('haproxy/haproxy_frontend_block.erb'),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,17 +12,26 @@
 # === Parameters
 #
 # [*package_ensure*]
-#   Chooses whether the haproxy package should be installed or uninstalled. Defaults to 'present'
+#   Chooses whether the haproxy package should be installed or uninstalled.
+#   Defaults to 'present'
 #
 # [*package_name*]
 #   The package name of haproxy. Defaults to 'haproxy'
+#   NOTE: haproxy::instance has a different default.
 #
 # [*service_ensure*]
 #   Chooses whether the haproxy service should be running & enabled at boot, or
 #   stopped and disabled at boot. Defaults to 'running'
 #
 # [*service_manage*]
-#   Chooses whether the haproxy service state should be managed by puppet at all. Defaults to true
+#   Chooses whether the haproxy service state should be managed by puppet at
+#   all. Defaults to true
+#
+# [*service_options*]
+#   Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
+#
+# [*service_options*]
+#   Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
 #
 # [*global_options*]
 #   A hash of all the haproxy global options. If you want to specify more
@@ -35,6 +44,12 @@
 #    than one option (i.e. multiple timeout or stats options), pass those
 #    options as an array and you will get a line for each of them in the
 #    resultant haproxy.cfg file.
+#
+# [*merge_options*]
+#   Whether to merge the user-supplied `global_options`/`defaults_options`
+#   hashes with their default values set in params.pp. Merging allows to change
+#   or add options without having to recreate the entire hash. Defaults to
+#   false, but will default to true in future releases.
 #
 #[*restart_command*]
 #   Command to use when restarting the on config changes.
@@ -83,8 +98,10 @@ class haproxy (
   $package_name     = $haproxy::params::package_name,
   $service_ensure   = 'running',
   $service_manage   = true,
+  $service_options  = $haproxy::params::service_options,
   $global_options   = $haproxy::params::global_options,
   $defaults_options = $haproxy::params::defaults_options,
+  $merge_options    = $haproxy::params::merge_options,
   $restart_command  = undef,
   $custom_fragment  = undef,
   $config_file      = $haproxy::params::config_file,
@@ -101,6 +118,13 @@ class haproxy (
   }
   validate_string($package_name,$package_ensure)
   validate_bool($service_manage)
+  validate_bool($merge_options)
+  validate_string($service_options)
+
+  # NOTE: These deprecating parameters are implemented in this class,
+  # not in haproxy::instance.  haproxy::instance is new and therefore
+  # there should be no legacy code that uses these deprecated
+  # parameters.
 
   # To support deprecating $enable
   if $enable != undef {
@@ -125,17 +149,18 @@ class haproxy (
     $_service_manage = $service_manage
   }
 
-  if $_package_ensure == 'absent' or $_package_ensure == 'purged' {
-    anchor { 'haproxy::begin': }
-    ~> class { 'haproxy::service': }
-    -> class { 'haproxy::config': }
-    -> class { 'haproxy::install': }
-    -> anchor { 'haproxy::end': }
-  } else {
-    anchor { 'haproxy::begin': }
-    -> class { 'haproxy::install': }
-    -> class { 'haproxy::config': }
-    ~> class { 'haproxy::service': }
-    -> anchor { 'haproxy::end': }
+  haproxy::instance{ $title:
+    package_ensure   => $_package_ensure,
+    package_name     => $package_name,
+    service_ensure   => $_service_ensure,
+    service_manage   => $_service_manage,
+    global_options   => $global_options,
+    defaults_options => $defaults_options,
+    restart_command  => $restart_command,
+    custom_fragment  => $custom_fragment,
+    config_file      => $config_file,
+    merge_options    => $merge_options,
+    service_options  => $service_options,
   }
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,12 +1,17 @@
 # Private class
-class haproxy::install inherits haproxy {
+define haproxy::install (
+  $package_ensure,
+  $package_name = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
+) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  package { $haproxy::package_name:
-    ensure => $haproxy::_package_ensure,
-    alias  => 'haproxy',
+  if $package_name != undef {
+    package { $package_name:
+      ensure => $package_ensure,
+      alias  => 'haproxy',
+    }
   }
 
   # Create default configuration directory, gentoo portage does not create it

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,0 +1,226 @@
+# == Define Resource Type: haproxy::instance
+#
+# Manages haproxy permitting multiple instances to run on the same machine.
+# Normally users use the Class['haproxy'], which runs a single haproxy
+# daemon on a machine.
+#
+# === Requirement/Dependencies:
+#
+# Currently requires the puppetlabs/concat module on the Puppet Forge and
+#  uses storeconfigs on the Puppet Master to export/collect resources
+#  from all balancer members.
+#
+# === Parameters
+#
+# [*package_ensure*]
+#   Chooses whether the haproxy package should be installed or uninstalled.
+#   Defaults to 'present'
+#
+# [*package_name*]
+#   The package name of haproxy. Defaults to undef, and no package is installed.
+#   NOTE: Class['haproxy'] has a different default.
+#
+# [*service_ensure*]
+#   Chooses whether the haproxy service should be running & enabled at boot, or
+#   stopped and disabled at boot. Defaults to 'running'
+#
+# [*service_manage*]
+#   Chooses whether the haproxy service state should be managed by puppet at
+#   all. Defaults to true
+#
+# [*global_options*]
+#   A hash of all the haproxy global options. If you want to specify more
+#    than one option (i.e. multiple timeout or stats options), pass those
+#    options as an array and you will get a line for each of them in the
+#    resultant haproxy.cfg file.
+#
+# [*defaults_options*]
+#   A hash of all the haproxy defaults options. If you want to specify more
+#    than one option (i.e. multiple timeout or stats options), pass those
+#    options as an array and you will get a line for each of them in the
+#    resultant haproxy.cfg file.
+#
+#[*restart_command*]
+#   Command to use when restarting the on config changes.
+#    Passed directly as the <code>'restart'</code> parameter to the service
+#    resource.  #    Defaults to undef i.e. whatever the service default is.
+#
+#[*custom_fragment*]
+#  Allows arbitrary HAProxy configuration to be passed through to support
+#  additional configuration not available via parameters, or to short-circuit
+#  the defined resources such as haproxy::listen when an operater would rather
+#  just write plain configuration. Accepts a string (ie, output from the
+#  template() function). Defaults to undef
+#
+#[*config_file*]
+#  Allows arbitrary config filename to be specified. If this is used,
+#  it is assumed that the directory path to the file exists and has
+#  owner/group/permissions as desired.  If set to undef, the name
+#  will be generated as follows:
+#    If $title is 'haproxy', the operating system default will be used.
+#    Otherwise, /etc/haproxy-$title/haproxy-$title.conf (Linux),
+#    or /usr/local/etc/haproxy-$title/haproxy-$title.conf (FreeBSD)
+#    The parent directory will be created automatically.
+#  Defaults to undef.
+#
+# === Examples
+#
+# A single instance of haproxy with all defaults
+# i.e. emulate Class['haproxy']
+#   package{ 'haproxy': ensure => present }->haproxy::instance { 'haproxy': }->
+#   haproxy::listen { 'puppet00':
+#     instance         => 'haproxy',
+#     collect_exported => false,
+#     ipaddress        => $::ipaddress,
+#     ports            => '8140',
+#   }
+#
+# Multiple instances of haproxy:
+#   haproxy::instance { 'group1': }
+#   haproxy::instance_service { 'group1':
+#     haproxy_init_source => "puppet:///modules/${module_name}/haproxy-group1.init",
+#   }
+#   haproxy::listen { 'puppet00':
+#     instance         => 'group1',
+#     collect_exported => false,
+#     ipaddress        => $::ipaddress,
+#     ports            => '8800',
+#     requires         => Package['haproxy'],
+#   }
+#   haproxy::instance { 'group2': }
+#   haproxy::instance_service { 'group2':
+#     haproxy_init_source => "puppet:///modules/${module_name}/haproxy-group1.init",
+#   }
+#   haproxy::listen { 'puppet00':
+#     instance         => 'group2',
+#     collect_exported => false,
+#     ipaddress        => $::ipaddress,
+#     ports            => '9900',
+#     requires         => Package['haproxy'],
+#   }
+#
+# Multiple instances of haproxy, one with a custom haproxy package:
+#   haproxy::instance { 'group1': }
+#   haproxy::instance_service { 'group1':
+#     haproxy_init_source => "puppet:///modules/${module_name}/haproxy-group1.init",
+#   }
+#   haproxy::listen { 'puppet00':
+#     instance         => 'group1',
+#     collect_exported => false,
+#     ipaddress        => $::ipaddress,
+#     ports            => '8800',
+#     requires         => Package['haproxy'],
+#   }
+#   haproxy::instance { 'group2': }
+#   haproxy::instance_service { 'group2':
+#     haproxy_package     => 'custom_haproxy',
+#     haproxy_init_source => "puppet:///modules/${module_name}/haproxy-group2.init",
+#   }
+#   haproxy::listen { 'puppet00':
+#     instance         => 'group2',
+#     collect_exported => false,
+#     ipaddress        => $::ipaddress,
+#     ports            => '9900',
+#     requires         => Package['haproxy'],
+#   }
+#
+#  When running multiple instances on one host, there must be a Service[] for
+#  each instance.  One way to create the situation where Service[] works is
+#  using haproxy::instance_service.
+#  However you may want to do it some other way. For example, you may
+#  not have packages for your custom haproxy binary. Or, you may wish
+#  to use the standard haproxy package but not create links to it, or
+#  you may have different init.d scripts.  In these cases, write your own
+#  puppet code that will result in Service[] working for you and do not
+#  call haproxy::instance_service.
+#
+define haproxy::instance (
+  $package_ensure   = 'present',
+  $package_name     = undef,
+  $service_ensure   = 'running',
+  $service_manage   = true,
+  $global_options   = undef,
+  $defaults_options = undef,
+  $restart_command  = undef,
+  $custom_fragment  = undef,
+  $config_file      = undef,
+  $merge_options    = $haproxy::params::merge_options,
+  $service_options  = $haproxy::params::service_options,
+) {
+
+  if $service_ensure != true and $service_ensure != false {
+    if ! ($service_ensure in [ 'running','stopped']) {
+      fail('service_ensure parameter must be running, stopped, true, or false')
+    }
+  }
+  validate_string($package_name,$package_ensure)
+  validate_bool($service_manage)
+
+  # Since this is a 'define', we can not use 'inherts haproxy::params'.
+  # Therefore, we "include haproxy::params" for any parameters we need.
+  include haproxy::params
+
+  $_global_options = pick($global_options, $haproxy::params::global_options, [])
+  $_defaults_options = pick($defaults_options, $haproxy::params::defaults_options, [])
+
+  # Determine instance_name based on:
+  #   single-instance hosts: haproxy
+  #   multi-instance hosts:  haproxy-$title
+  if $title == 'haproxy' {
+    $instance_name = 'haproxy'
+  } else {
+    $instance_name = "haproxy-${title}"
+  }
+
+  # Determine config_dir and config_file:
+  #   If config_dir defined, use it.  Otherwise:
+  #   single-instance hosts: use defaults
+  #   multi-instance hosts:  use templates
+  if $config_file != undef {
+    $_config_dir = undef
+    $_config_file = $config_file
+  } else {
+    if $instance_name == 'haproxy' {
+      $_config_dir = $haproxy::params::config_dir
+      $_config_file = $haproxy::params::config_file
+    } else {
+      $_config_dir = inline_template($haproxy::params::config_dir_tmpl)
+      $_config_file = inline_template($haproxy::params::config_file_tmpl)
+    }
+  }
+
+  haproxy::config { $title:
+    instance_name    => $instance_name,
+    config_dir       => $_config_dir,
+    config_file      => $_config_file,
+    global_options   => $_global_options,
+    defaults_options => $_defaults_options,
+    custom_fragment  => $custom_fragment,
+    merge_options    => $merge_options,
+  }
+  haproxy::install { $title:
+    package_name   => $package_name,
+    package_ensure => $package_ensure,
+  }
+  haproxy::service { $title:
+    instance_name   => $instance_name,
+    service_ensure  => $service_ensure,
+    service_manage  => $service_manage,
+    restart_command => $restart_command,
+    service_options => $service_options,
+  }
+
+  if $package_ensure == 'absent' or $package_ensure == 'purged' {
+    anchor { "${title}::haproxy::begin": }
+    ~> Haproxy::Service[$title]
+    -> Haproxy::Config[$title]
+    -> Haproxy::Install[$title]
+    -> anchor { "${title}::haproxy::end": }
+  } else {
+    anchor { "${title}::haproxy::begin": }
+    -> Haproxy::Install[$title]
+    -> Haproxy::Config[$title]
+    ~> Haproxy::Service[$title]
+    -> anchor { "${title}::haproxy::end": }
+  }
+}

--- a/manifests/instance_service.pp
+++ b/manifests/instance_service.pp
@@ -1,0 +1,131 @@
+# == Define: haproxy::instance_service
+#
+# Set up the environment for an haproxy service.
+#   * Associate an haproxy instance with the haproxy package it should use.
+#   * Create the start/restart/stop functions needed by Service[].
+# In other words: sets things up so that Service[$instance_name] will work.
+#
+# In particular:
+# * Create a link to the binary an instance will be using. This
+#   way each instance can link to a different binary.
+#   If you have an instance called "foo", you know "haproxy-foo"
+#   is a link to the binary it should be using.
+# * Create an init.d file named after the instance. This way
+#   Service[$instance] can start/restart the service.
+#
+# NOTE:
+# This manifest is just one example of how to set up Service[$instance].
+# Other sites may choose to do it very differently. In that case, do
+# not call haproxy::instance_service; write your own module.  The only
+# requirement is that before haproxy::instance{$instance:} is called,
+# Service[$instance] must be defined.
+#
+# FIXME: This hasn't been tested on FreeBSD.
+# FIXME: This should take advantage of systemd when available.
+#
+# === Parameters
+#
+# [*haproxy_package*]
+#   The name of the package to be installed. This is useful if
+#   you package your own custom version of haproxy.
+#   Defaults to 'haproxy'
+#
+# [*bindir*]
+#   Where to put symlinks to the binary used for each instance.
+#   Defaults to '/opt/haproxy'
+#
+# [*haproxy_init_source*]
+#   The init.d script that will start/restart/reload this instance.
+#
+define haproxy::instance_service (
+  $haproxy_init_source = undef,
+  $haproxy_unit_template = undef,
+  $haproxy_package = 'haproxy',
+  $bindir = '/opt/haproxy/bin',
+) {
+
+  ensure_resource('package', $haproxy_package, {
+    'ensure' => 'present',
+  })
+
+  # Manage the parent directory.
+  ensure_resource('file', $bindir, {
+    ensure => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0744',
+  })
+
+  # Create a link named after the instance. This just makes it easier
+  # to manage difference instances using different versions of haproxy.
+  # If you have an instance called "foo", you know "haproxy-foo"
+  # is the binary.
+  $haproxy_link = "${bindir}/haproxy-${title}"
+  if $haproxy_package == 'haproxy' {
+    $haproxy_target = '/usr/sbin/haproxy'
+  } else {
+    $haproxy_target = "/opt/${haproxy_package}/sbin/haproxy"
+  }
+  file { $haproxy_link:
+    ensure => link,
+    target => $haproxy_target,
+  }
+
+  # Create init.d or systemd files so that "service haproxy-$instance start"
+  # or "systemd start haproxy-$instance" works.
+  # This is not required if the standard instance is being used.
+  if ($title == 'haproxy') or ($haproxy_package == 'haproxy') {
+  } else {
+    $initfile = "/etc/init.d/haproxy-${title}"
+    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
+
+      # init.d:
+      validate_string($haproxy_init_source)
+      file { $initfile:
+        ensure => file,
+        mode   => '0744',
+        owner  => 'root',
+        group  => 'root',
+        source => $haproxy_init_source,
+      }
+      File[$haproxy_link] -> File[$initfile]
+
+    } else {
+
+      # systemd:
+      validate_string($haproxy_unit_template)
+      if $haproxy_package == 'haproxy' {
+        $wrapper = '/usr/sbin/haproxy-systemd-wrapper'
+      } else {
+        $wrapper = "/opt/${haproxy_package}/sbin/haproxy-systemd-wrapper"
+      }
+
+      $unitfile = "/usr/lib/systemd/system/haproxy-${title}.service"
+      file { $unitfile:
+        ensure  => file,
+        mode    => '0744',
+        owner   => 'root',
+        group   => 'root',
+        content => template($haproxy_unit_template),
+        notify  => Exec['systemctl daemon-reload'],
+      }
+      if (!defined(Exec['systemctl daemon-reload'])) {
+        exec { 'systemctl daemon-reload':
+          command     => 'systemctl daemon-reload',
+          path        => '/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin',
+          refreshonly => true,
+          before      => Service["haproxy-${title}"],
+        }
+      }
+      File[$haproxy_link] -> File[$unitfile]
+      # Clean up in case the old init.d-style file is still around.
+      file { $initfile:
+        ensure => absent,
+        before => Service["haproxy-${title}"],
+      }
+
+    }
+  }
+
+  Package[$haproxy_package] -> File[$bindir] -> File[$haproxy_link]
+}

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -16,9 +16,9 @@
 #
 # === Parameters
 #
-# [*name*]
-#   The namevar of the defined resource type is the listening service's name.
+# [*section_name*]
 #    This name goes right after the 'listen' statement in haproxy.cfg
+#    Default: $name (the namevar of the resource).
 #
 # [*ports*]
 #   Ports on which the proxy will listen for connections on the ip address
@@ -88,10 +88,11 @@ define haproxy::listen (
     ],
     'balance' => 'roundrobin'
   },
+  $instance                     = 'haproxy',
+  $section_name                 = $name,
   # Deprecated
   $bind_options                 = '',
 ) {
-
   if $ports and $bind {
     fail('The use of $ports and $bind is mutually exclusive, please choose either one')
   }
@@ -105,19 +106,28 @@ define haproxy::listen (
     validate_hash($bind)
   }
 
-  if defined(Haproxy::Backend[$name]) {
-    fail("An haproxy::backend resource was discovered with the same name (${name}) which is not supported")
+  if defined(Haproxy::Backend[$section_name]) {
+    fail("An haproxy::backend resource was discovered with the same name (${section_name}) which is not supported")
   }
 
-  # Template uses: $name, $ipaddress, $ports, $options
-  concat::fragment { "${name}_listen_block":
-    order   => "20-${name}-00",
-    target  => $::haproxy::config_file,
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $config_file = $haproxy::params::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
+  # Template uses: $section_name, $ipaddress, $ports, $options
+  concat::fragment { "${instance_name}-${section_name}_listen_block":
+    order   => "20-${section_name}-00",
+    target  => $config_file,
     content => template('haproxy/haproxy_listen_block.erb'),
   }
 
   if $collect_exported {
-    haproxy::balancermember::collect_exported { $name: }
+    haproxy::balancermember::collect_exported { $section_name: }
   }
   # else: the resources have been created and they introduced their
   # concat fragments. We don't have to do anything about them.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,11 @@
 #  extended by changing package names and configuration file paths.
 #
 class haproxy::params {
+  # XXX: This will change to true in the next major release
+  $merge_options = false
+
+  $service_options  = "ENABLED=1\n"  # Only used by Debian.
+
   case $::osfamily {
     'Archlinux', 'Debian', 'Redhat', 'Gentoo', 'Suse' : {
       $package_name     = 'haproxy'
@@ -21,7 +26,7 @@ class haproxy::params {
       $defaults_options = {
         'log'     => 'global',
         'stats'   => 'enable',
-        'option'  => 'redispatch',
+        'option'  => [ 'redispatch' ],
         'retries' => '3',
         'timeout' => [
           'http-request 10s',
@@ -33,7 +38,12 @@ class haproxy::params {
         ],
         'maxconn' => '8000'
       }
+      # Single instance:
+      $config_dir       = '/etc/haproxy'
       $config_file      = '/etc/haproxy/haproxy.cfg'
+      # Multi-instance:
+      $config_dir_tmpl  = '/etc/<%= @instance_name %>'
+      $config_file_tmpl = "${config_dir_tmpl}/<%= @instance_name %>.cfg"
     }
     'FreeBSD': {
       $package_name     = 'haproxy'
@@ -61,8 +71,16 @@ class haproxy::params {
         'clitimeout' => '50000',
         'srvtimeout' => '50000',
       }
+      # Single instance:
+      $config_dir       = '/usr/local/etc'
       $config_file      = '/usr/local/etc/haproxy.conf'
+      # Multi-instance:
+      $config_dir_tmpl  = '/usr/local/etc/<%= @instance_name %>'
+      $config_file_tmpl = "${config_dir_tmpl}/<%= @instance_name %>.conf"
     }
     default: { fail("The ${::osfamily} operating system is not supported with the haproxy module") }
   }
 }
+
+# TODO: test that the $config_file generated for FreeBSD instances
+#  and RedHat instances is as expected.

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -1,7 +1,7 @@
 # == Define Resource Type: haproxy::peer
 #
 # This type will set up a peer entry inside the peers configuration block in
-# /etc/haproxy/haproxy.cfg on the load balancer. Currently, it has the ability to
+# haproxy.cfg on the load balancer. Currently, it has the ability to
 # specify the instance name, ip address, ports and server_names.
 #
 # Automatic discovery of peer nodes may be implemented by exporting the peer resource
@@ -39,13 +39,23 @@ define haproxy::peer (
   $ensure       = 'present',
   $server_names = $::hostname,
   $ipaddresses  = $::ipaddress,
+  $instance = 'haproxy',
 ) {
 
-  # Templats uses $ipaddresses, $server_name, $ports, $option
-  concat::fragment { "peers-${peers_name}-${name}":
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $config_file = $::haproxy::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
+  # Templates uses $ipaddresses, $server_name, $ports, $option
+  concat::fragment { "${instance_name}-peers-${peers_name}-${name}":
     ensure  => $ensure,
     order   => "30-peers-01-${peers_name}-${name}",
-    target  => '/etc/haproxy/haproxy.cfg',
+    target  => $config_file,
     content => template('haproxy/haproxy_peer.erb'),
   }
 }

--- a/manifests/peers.pp
+++ b/manifests/peers.pp
@@ -1,6 +1,6 @@
 # == Defined Type: haproxy::peers
 #
-#  This type will set up a peers entry in /etc/haproxy/haproxy.cfg
+#  This type will set up a peers entry in haproxy.cfg
 #   on the load balancer. This setting is required to share the
 #   current state of HAproxy with other HAproxy in High available
 #   configurations.
@@ -14,12 +14,23 @@
 
 define haproxy::peers (
   $collect_exported = true,
+  $instance = 'haproxy',
 ) {
 
+  # We derive these settings so that the caller only has to specify $instance.
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $config_file = $::haproxy::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
   # Template uses: $name, $ipaddress, $ports, $options
-  concat::fragment { "${name}_peers_block":
+  concat::fragment { "${instance_name}-${name}_peers_block":
     order   => "30-peers-00-${name}",
-    target  => '/etc/haproxy/haproxy.cfg',
+    target  => $config_file,
     content => template('haproxy/haproxy_peers_block.erb'),
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,30 +1,36 @@
 # Private class
-class haproxy::service inherits haproxy {
+define haproxy::service (
+  $instance_name,
+  $service_ensure,
+  $service_manage,
+  $restart_command = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
+  $service_options = $haproxy::params::service_options,
+) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $haproxy::_service_manage {
+  if $service_manage {
     if ($::osfamily == 'Debian') {
-      file { '/etc/default/haproxy':
-        content => 'ENABLED=1',
-        before  => Service['haproxy'],
+      file { "/etc/default/${instance_name}":
+        content => $service_options,
+        before  => Service[$instance_name],
       }
     }
 
-    $_service_enable = $haproxy::_service_ensure ? {
-      'running' => true,
-      'stopped' => false,
-      default   => $haproxy::_service_ensure,
+    $_service_enable = $service_ensure ? {
+        'running' => true,
+        'stopped' => false,
+        default   => $service_ensure,
     }
 
-    service { 'haproxy':
-      ensure     => $haproxy::_service_ensure,
+    service { $instance_name:
+      ensure     => $service_ensure,
       enable     => $_service_enable,
-      name       => 'haproxy',
+      name       => $instance_name,
       hasrestart => true,
       hasstatus  => true,
-      restart    => $haproxy::restart_command,
+      restart    => $restart_command,
     }
   }
 }

--- a/manifests/userlist.pp
+++ b/manifests/userlist.pp
@@ -11,9 +11,9 @@
 #
 # === Parameters
 #
-# [*name*]
-#   The namevar of the define resource type is the userlist name.
+# [*section_name*]
 #    This name goes right after the 'userlist' statement in haproxy.cfg
+#    Default: $name (the namevar of the resource).
 #
 # [*users*]
 #   An array of users in the userlist.
@@ -30,12 +30,22 @@
 define haproxy::userlist (
   $users = undef,
   $groups = undef,
+  $instance = 'haproxy',
+  $section_name = $name,
 ) {
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $config_file = $haproxy::params::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
 
-  # Template usse $name, $users, $groups
-  concat::fragment { "${name}_userlist_block":
-    order   => "12-${name}-00",
-    target  => $::haproxy::config_file,
+  # Template uses $section_name, $users, $groups
+  concat::fragment { "${instance_name}-${section_name}_userlist_block":
+    order   => "12-${section_name}-00",
+    target  => $config_file,
     content => template('haproxy/haproxy_userlist_block.erb'),
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-haproxy",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Puppet Labs",
   "summary": "Configures HAProxy servers and manages the configuration of backend member servers.",
   "license": "Apache-2.0",
@@ -59,15 +59,15 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 2015.3.0"
     },
     {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 2.4.0 < 5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.2.3 < 2.0.0"}
   ]
 }

--- a/spec/defines/backend_spec.rb
+++ b/spec/defines/backend_spec.rb
@@ -13,7 +13,7 @@ describe 'haproxy::backend' do
   context "when no options are passed" do
     let(:title) { 'bar' }
 
-    it { should contain_concat__fragment('bar_backend_block').with(
+    it { should contain_concat__fragment('haproxy-bar_backend_block').with(
       'order'   => '20-bar-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nbackend bar\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -22,7 +22,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server dero 1.1.1.1:18140 check\n"
@@ -39,7 +39,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'ensure'  => 'absent',
@@ -57,7 +57,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server dero 1.1.1.1:18140 check close\n"
@@ -75,7 +75,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server dero 1.1.1.1:18140 cookie dero check close\n"
@@ -93,7 +93,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server server01 192.168.56.200:18140 check\n  server server02 192.168.56.201:18140 check\n"
@@ -111,7 +111,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server server01 192.168.56.200:18140 check\n  server server01 192.168.56.200:18150 check\n  server server02 192.168.56.201:18140 check\n  server server02 192.168.56.201:18150 check\n"
@@ -128,7 +128,7 @@ describe 'haproxy::balancermember' do
       }
     end
 
-    it { should contain_concat__fragment('croy_balancermember_tyler').with(
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
       'order'   => '20-croy-01-tyler',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "  server server01 192.168.56.200 check\n  server server02 192.168.56.201 check\n"

--- a/spec/defines/frontend_spec.rb
+++ b/spec/defines/frontend_spec.rb
@@ -19,7 +19,7 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('croy_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-croy_frontend_block').with(
       'order'   => '15-croy-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nfrontend croy\n  bind 1.1.1.1:18140 \n  option tcplog\n"
@@ -38,7 +38,7 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option tcplog\n"
@@ -54,7 +54,7 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option tcplog\n"
@@ -70,7 +70,7 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nfrontend apache\n  option tcplog\n"
@@ -141,7 +141,7 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.24:80 \n  option tcplog\n"
@@ -157,7 +157,7 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nfrontend apache\n  bind 1.1.1.1:80 the options go here\n  bind 1.1.1.1:8080 the options go here\n  option tcplog\n"
@@ -172,7 +172,7 @@ describe 'haproxy::frontend' do
       }
     end
 
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nfrontend apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  option tcplog\n"
@@ -186,7 +186,7 @@ describe 'haproxy::frontend' do
         :bind  => {'1.1.1.1:80' => []},
       }
     end
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nfrontend apache\n  bind 1.1.1.1:80 \n  option tcplog\n"
@@ -206,10 +206,32 @@ describe 'haproxy::frontend' do
         },
       }
     end
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nfrontend apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  option tcplog\n"
+      'content' => "\nfrontend apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  option tcplog\n"
+    ) }
+  end
+
+  context "when bind parameter is used with ip addresses that sort wrong lexigraphically" do
+    let(:params) do
+      {
+        :name  => 'apache',
+        :bind  => {
+          '10.1.3.21:80'      => [],
+          '8.252.206.100:80'  => [],
+          '8.252.206.101:80'  => [],
+          '8.252.206.99:80'   => [],
+          '1.1.1.1:80'        => [],
+          ':443,:8443'        => [ 'ssl', 'crt public.puppetlabs.com', 'no-sslv3' ],
+          '2.2.2.2:8000-8010' => [ 'ssl', 'crt public.puppetlabs.com' ],
+        },
+      }
+    end
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
+      'order'   => '15-apache-00',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "\nfrontend apache\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind 8.252.206.99:80 \n  bind 8.252.206.100:80 \n  bind 8.252.206.101:80 \n  bind 10.1.3.21:80 \n  option tcplog\n"
     ) }
   end
 
@@ -233,7 +255,7 @@ describe 'haproxy::frontend' do
         ],
       }
     end
-    it { should contain_concat__fragment('apache_frontend_block').with(
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
       'order'   => '15-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nfrontend apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  reqadd X-Forwarded-Proto:\\ https\n  default_backend dev00_webapp\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  bind-process all\n  compression algo gzip\n"

--- a/spec/defines/instance_service_spec.rb
+++ b/spec/defines/instance_service_spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper'
+
+describe 'haproxy::instance_service' do
+  let(:default_facts) do
+    {
+      :concat_basedir => '/dne',
+      :ipaddress      => '10.10.10.10'
+    }
+  end
+  let(:params) do
+    {
+      'haproxy_init_source' => 'foo'
+    }
+  end
+
+  context 'on any platform' do
+
+    # haproxy::instance 'haproxy' with defaults
+
+    context 'with title haproxy and defaults params' do
+      let(:title) { 'haproxy' }
+      let(:params) do
+        {
+          'haproxy_init_source' => '/foo/bar'
+        }
+      end
+      it 'should install the haproxy package' do
+        subject.should contain_package('haproxy').with(
+          'ensure' => 'present'
+        )
+      end
+      it 'should create the exec directory' do
+        subject.should contain_file('/opt/haproxy/bin').with(
+          'ensure' => 'directory',
+          'owner'  => 'root',
+          'group'  => 'root',
+          'mode'   => '0744'
+        )
+      end
+      it 'should create a link to the exec' do
+        subject.should contain_file('/opt/haproxy/bin/haproxy-haproxy').with(
+          'ensure' => 'link',
+          'target' => '/usr/sbin/haproxy'
+        )
+      end
+      it 'should not create an init.d file' do
+        subject.should_not contain_file('/etc/init.d/haproxy-haproxy').with(
+          'ensure' => 'file'
+        )
+      end
+    end
+
+  # haproxy::instance 'haproxy' with custom settings
+
+  context 'with title group1 and custom settings' do
+    let(:title) { 'haproxy' }
+    let(:params) do
+      {
+        'haproxy_package'     => 'customhaproxy',
+        'bindir'              => '/weird/place',
+        'haproxy_init_source' => '/foo/bar'
+      }
+    end
+    it 'should install the customhaproxy package' do
+      subject.should contain_package('customhaproxy').with(
+        'ensure' => 'present'
+      )
+    end
+    it 'should create the exec directory' do
+      subject.should contain_file('/weird/place').with(
+        'ensure' => 'directory',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0744'
+      )
+    end
+    it 'should create a link to the exec' do
+      subject.should contain_file('/weird/place/haproxy-haproxy').with(
+        'ensure' => 'link',
+        'target' => '/opt/customhaproxy/sbin/haproxy'
+      )
+    end
+    it 'should not create an init.d file' do
+      subject.should_not contain_file('/etc/init.d/haproxy-haproxy').with(
+        'ensure' => 'file'
+      )
+    end
+    it 'should not manage the default init.d file' do
+      subject.should_not contain_file('/etc/init.d/haproxy').with(
+        'ensure' => 'file'
+      )
+    end
+  end
+
+  # haproxy::instance 'group1' with defaults
+
+    context 'with title group1 and defaults params' do
+      let(:title) { 'group1' }
+      let(:params) do
+        {
+          'haproxy_init_source' => '/foo/bar'
+        }
+      end
+      it 'should install the haproxy package' do
+        subject.should contain_package('haproxy').with(
+          'ensure' => 'present'
+        )
+      end
+      it 'should create the exec directory' do
+        subject.should contain_file('/opt/haproxy/bin').with(
+          'ensure' => 'directory',
+          'owner'  => 'root',
+          'group'  => 'root',
+          'mode'   => '0744'
+        )
+      end
+      it 'should create a link to the exec' do
+        subject.should contain_file('/opt/haproxy/bin/haproxy-group1').with(
+          'ensure' => 'link',
+          'target' => '/usr/sbin/haproxy'
+        )
+      end
+      it 'should not create an init.d file' do
+        subject.should_not contain_file('/etc/init.d/haproxy-haproxy').with(
+          'ensure' => 'file'
+        )
+      end
+    end
+  end
+
+  # haproxy::instance 'group1' with custom settings
+
+  context 'with title group1 and defaults params' do
+    let(:title) { 'group1' }
+    let(:params) do
+      {
+        'haproxy_package'     => 'customhaproxy',
+        'bindir'              => '/weird/place',
+        'haproxy_init_source' => '/init/source/haproxy',
+        'haproxy_unit_template' => "haproxy/instance_service_unit_example.erb"
+      }
+    end
+    it 'should install the customhaproxy package' do
+      subject.should contain_package('customhaproxy').with(
+        'ensure' => 'present'
+      )
+    end
+    it 'should create the exec directory' do
+      subject.should contain_file('/weird/place').with(
+        'ensure' => 'directory',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0744'
+      )
+    end
+    it 'should create a link to the exec' do
+      subject.should contain_file('/weird/place/haproxy-group1').with(
+        'ensure' => 'link',
+        'target' => '/opt/customhaproxy/sbin/haproxy'
+      )
+    end
+    it 'should remove any obsolete init.d file' do
+      subject.should contain_file('/etc/init.d/haproxy-group1').with(
+        'ensure' => 'absent'
+      )
+    end
+  end
+
+end

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -1,15 +1,19 @@
 require 'spec_helper'
 
-describe 'haproxy', :type => :class do
+describe 'haproxy::instance' do
   let(:default_facts) do
     {
       :concat_basedir => '/dne',
       :ipaddress      => '10.10.10.10'
     }
   end
+
+  # haproxy::instance with service name "haproxy".
+
   context 'on supported platforms' do
+    let(:title) { 'haproxy' }
     describe 'for OS-agnostic configuration' do
-      ['Debian', 'RedHat', 'Archlinux', 'FreeBSD', 'Gentoo',].each do |osfamily|
+      ['Debian', 'RedHat', 'Archlinux', 'FreeBSD',].each do |osfamily|
         context "on #{osfamily} family operatingsystems" do
           let(:facts) do
             { :osfamily => osfamily }.merge default_facts
@@ -18,6 +22,7 @@ describe 'haproxy', :type => :class do
             {
               'service_ensure' => 'running',
               'package_ensure' => 'present',
+              'package_name'   => 'haproxy',
               'service_manage' => true
             }
           end
@@ -53,7 +58,7 @@ describe 'haproxy', :type => :class do
     end
 
     describe 'for linux operating systems' do
-      ['Debian', 'RedHat', 'Archlinux', 'Gentoo', ].each do |osfamily|
+      ['Debian', 'RedHat', 'Archlinux', ].each do |osfamily|
         context "on #{osfamily} family operatingsystems" do
           let(:facts) do
             { :osfamily => osfamily }.merge default_facts
@@ -109,23 +114,6 @@ describe 'haproxy', :type => :class do
             end
           end
         end
-        context "on #{osfamily} family operatingsystems with setting haproxy.cfg location" do
-          let(:facts) do
-            { :osfamily => osfamily }.merge default_facts
-          end
-          let(:params) do
-            {
-              'config_file' => '/tmp/haproxy.cfg',
-            }
-          end
-          it 'should set up /tmp/haproxy.cfg as a concat resource' do
-            subject.should contain_concat('/tmp/haproxy.cfg').with(
-              'owner' => '0',
-              'group' => '0',
-              'mode'  => '0644'
-            )
-          end
-        end
         context "on #{osfamily} family operatingsystems without managing the service" do
           let(:facts) do
             { :osfamily => osfamily }.merge default_facts
@@ -134,6 +122,7 @@ describe 'haproxy', :type => :class do
             {
               'service_ensure' => true,
               'package_ensure' => 'present',
+              'package_name'   => 'haproxy',
               'service_manage' => false
             }
           end
@@ -211,8 +200,211 @@ describe 'haproxy', :type => :class do
         end
       end
     end
+  end
+
+  # haproxy::instance with 2nd instance and with non-standard service name.
+
+  context 'on supported platforms' do
+    let(:title) { 'group1' }
+    describe 'for OS-agnostic configuration' do
+      ['Debian', 'RedHat', 'Archlinux', 'FreeBSD',].each do |osfamily|
+        context "on #{osfamily} family operatingsystems" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'service_ensure' => 'running',
+              'package_ensure' => 'present',
+              'package_name'   => 'customhaproxy',
+              'service_manage' => true
+            }
+          end
+          it 'should install the customhaproxy package' do
+            subject.should contain_package('customhaproxy').with(
+              'ensure' => 'present'
+            )
+          end
+          it 'should install the customhaproxy service' do
+            subject.should contain_service('haproxy-group1').with(
+              'ensure'     => 'running',
+              'enable'     => 'true',
+              'hasrestart' => 'true',
+              'hasstatus'  => 'true'
+            )
+          end
+          it 'should not install the haproxy package' do
+            subject.should_not contain_package('haproxy')
+          end
+          it 'should not install the haproxy service' do
+            subject.should_not contain_service('haproxy')
+          end
+        end
+        # C9938
+        context "on #{osfamily} when specifying custom content" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            { 'custom_fragment' => "listen stats :9090\n  mode http\n  stats uri /\n  stats auth puppet:puppet\n" }
+          end
+          it 'should set the haproxy-group1 package' do
+            subject.should contain_concat__fragment('haproxy-group1-haproxy-base').with_content(
+              /listen stats :9090\n  mode http\n  stats uri \/\n  stats auth puppet:puppet\n/
+            )
+          end
+        end
+      end
+    end
+
+    describe 'for linux operating systems' do
+      ['Debian', 'RedHat', 'Archlinux', ].each do |osfamily|
+        context "on #{osfamily} family operatingsystems" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          it 'should set up /etc/haproxy-group1/haproxy-group1.cfg as a concat resource' do
+            subject.should contain_concat('/etc/haproxy-group1/haproxy-group1.cfg').with(
+              'owner' => '0',
+              'group' => '0',
+              'mode'  => '0644'
+            )
+          end
+          it 'should manage the chroot directory' do
+            subject.should contain_file('/var/lib/haproxy').with(
+              'ensure' => 'directory',
+              'owner'  => 'haproxy',
+              'group'  => 'haproxy'
+            )
+          end
+          it 'should contain a header concat fragment' do
+            subject.should contain_concat__fragment('haproxy-group1-00-header').with(
+              'target'  => '/etc/haproxy-group1/haproxy-group1.cfg',
+              'order'   => '01',
+              'content' => "# This file managed by Puppet\n"
+            )
+          end
+          it 'should contain a haproxy-group1-haproxy-base concat fragment' do
+            subject.should contain_concat__fragment('haproxy-group1-haproxy-base').with(
+              'target'  => '/etc/haproxy-group1/haproxy-group1.cfg',
+              'order'   => '10'
+            )
+          end
+          describe 'Base concat fragment contents' do
+            let(:contents) { param_value(catalogue, 'concat::fragment', 'haproxy-group1-haproxy-base', 'content').split("\n") }
+            # C9936 C9937
+            it 'should contain global and defaults sections' do
+              contents.should include('global')
+              contents.should include('defaults')
+            end
+            it 'should log to an ip address for local0' do
+              contents.should be_any { |match| match =~ /  log  \d+(\.\d+){3} local0/ }
+            end
+            it 'should specify the default chroot' do
+              contents.should include('  chroot  /var/lib/haproxy')
+            end
+            it 'should specify the correct user' do
+              contents.should include('  user  haproxy')
+            end
+            it 'should specify the correct group' do
+              contents.should include('  group  haproxy')
+            end
+            it 'should specify the correct pidfile' do
+              contents.should include('  pidfile  /var/run/haproxy.pid')
+            end
+          end
+        end
+        context "on #{osfamily} family operatingsystems without managing the service" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'service_ensure' => true,
+              'package_ensure' => 'present',
+              'package_name'   => 'customhaproxy',
+              'service_manage' => false
+            }
+          end
+          it 'should install the customhaproxy package' do
+            subject.should contain_package('customhaproxy').with(
+              'ensure' => 'present'
+            )
+          end
+          it 'should not manage the customhaproxy service' do
+            subject.should_not contain_service('haproxy-group1')
+          end
+          it 'should set up /etc/haproxy-group1/haproxy-group1.cfg as a concat resource' do
+            subject.should contain_concat('/etc/haproxy-group1/haproxy-group1.cfg').with(
+              'owner' => '0',
+              'group' => '0',
+              'mode'  => '0644'
+            )
+          end
+          it 'should manage the chroot directory' do
+            subject.should contain_file('/var/lib/haproxy').with(
+              'ensure' => 'directory'
+            )
+          end
+          it 'should contain a header concat fragment' do
+            subject.should contain_concat__fragment('haproxy-group1-00-header').with(
+              'target'  => '/etc/haproxy-group1/haproxy-group1.cfg',
+              'order'   => '01',
+              'content' => "# This file managed by Puppet\n"
+            )
+          end
+          it 'should contain a haproxy-group1-haproxy-base concat fragment' do
+            subject.should contain_concat__fragment('haproxy-group1-haproxy-base').with(
+              'target'  => '/etc/haproxy-group1/haproxy-group1.cfg',
+              'order'   => '10'
+            )
+          end
+          describe 'Base concat fragment contents' do
+            let(:contents) { param_value(catalogue, 'concat::fragment', 'haproxy-group1-haproxy-base', 'content').split("\n") }
+            it 'should contain global and defaults sections' do
+              contents.should include('global')
+              contents.should include('defaults')
+            end
+            it 'should log to an ip address for local0' do
+              contents.should be_any { |match| match =~ /  log  \d+(\.\d+){3} local0/ }
+            end
+            it 'should specify the default chroot' do
+              contents.should include('  chroot  /var/lib/haproxy')
+            end
+            it 'should specify the correct user' do
+              contents.should include('  user  haproxy')
+            end
+            it 'should specify the correct group' do
+              contents.should include('  group  haproxy')
+            end
+            it 'should specify the correct pidfile' do
+              contents.should include('  pidfile  /var/run/haproxy.pid')
+            end
+          end
+        end
+        context "on #{osfamily} when specifying a restart_command" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'restart_command' => '/etc/init.d/haproxy-group1 reload',
+              'service_manage'  => true
+            }
+          end
+          it 'should set the customhaproxy package' do
+            subject.should contain_service('haproxy-group1').with(
+              'restart' => '/etc/init.d/haproxy-group1 reload'
+            )
+          end
+        end
+      end
+    end
+
+    # FreeBSD: haproxy::instance with service name "haproxy".
 
     describe 'for freebsd' do
+      let(:title) { 'haproxy' }
       context "on freebsd family operatingsystems" do
         let(:facts) do
           { :osfamily => 'FreeBSD' }.merge default_facts
@@ -268,6 +460,7 @@ describe 'haproxy', :type => :class do
           {
             'service_ensure' => true,
             'package_ensure' => 'present',
+            'package_name'   => 'haproxy',
             'service_manage' => false
           }
         end
@@ -339,14 +532,30 @@ describe 'haproxy', :type => :class do
       end
     end
 
+    # OS-specific configurations:
+
     describe 'for OS-specific configuration' do
       context 'only on Debian family operatingsystems' do
         let(:facts) do
           { :osfamily => 'Debian' }.merge default_facts
         end
         it 'should manage haproxy service defaults' do
-          subject.should contain_file('/etc/default/haproxy')
-          verify_contents(catalogue, '/etc/default/haproxy', ['ENABLED=1'])
+          subject.should contain_file('/etc/default/haproxy-group1')
+          verify_contents(catalogue, '/etc/default/haproxy-group1', ['ENABLED=1'])
+        end
+      end
+      context 'only on Debian family operatingsystems with custom /etc/default' do
+        let(:facts) do
+          { :osfamily => 'Debian' }.merge default_facts
+        end
+        let(:params) do
+          {
+            'service_options' => 'stuff'
+          }
+        end
+        it 'should manage haproxy service defaults' do
+          subject.should contain_file('/etc/default/haproxy-group1')
+          verify_contents(catalogue, '/etc/default/haproxy-group1', ['stuff'])
         end
       end
       context 'only on RedHat family operatingsystems' do
@@ -354,118 +563,13 @@ describe 'haproxy', :type => :class do
           { :osfamily => 'RedHat' }.merge default_facts
         end
       end
-      context 'only on Gentoo family operatingsystems' do
-        let(:facts) do
-          { :osfamily => 'Gentoo' }.merge default_facts
-        end
-        it 'should create directory /etc/haproxy' do
-          subject.should contain_file('/etc/haproxy').with(
-            'ensure' => 'directory'
-          )
-        end
-      end
-    end
-
-    describe 'when merging global and defaults options with user-supplied overrides and additions' do
-      # For testing the merging functionality we restrict ourselves to
-      # Debian OS family so that we don't have to juggle different sets of
-      # global_options and defaults_options (like for FreeBSD).
-      ['Debian' ].each do |osfamily|
-        context "on #{osfamily} family operatingsystems" do
-          let(:facts) do
-            { :osfamily => osfamily }.merge default_facts
-          end
-          let(:contents) { param_value(catalogue, 'concat::fragment', 'haproxy-haproxy-base', 'content').split("\n") }
-          let(:params) do
-            {
-              'merge_options'   => true,
-              'global_options'  => {
-                'log-send-hostname' => '',
-                'chroot'            => '/srv/haproxy-chroot',
-                'maxconn'           => nil,
-                'stats'             => [
-                  'socket /var/lib/haproxy/admin.sock mode 660 level admin',
-                  'timeout 30s'
-                ]
-              },
-              'defaults_options' => {
-                'mode'    => 'http',
-                'option'  => [
-                  'abortonclose',
-                  'logasap',
-                  'dontlognull',
-                  'httplog',
-                  'http-server-close',
-                  'forwardfor except 127.0.0.1',
-                ],
-                'timeout' => [
-                  'connect 5s',
-                  'client 1m',
-                  'server 1m',
-                  'check 7s',
-                ]
-              },
-            }
-          end
-          it 'should manage a custom chroot directory' do
-            subject.should contain_file('/srv/haproxy-chroot').with(
-              'ensure' => 'directory',
-              'owner'  => 'haproxy',
-              'group'  => 'haproxy'
-            )
-          end
-          it 'should contain global and defaults sections' do
-            contents.should include('global')
-            contents.should include('defaults')
-          end
-          it 'should send hostname with log in global options' do
-            contents.should include('  log-send-hostname  ')
-          end
-          it 'should enable admin stats and stats timeout in global options' do
-            contents.should include('  stats  socket /var/lib/haproxy/admin.sock mode 660 level admin')
-            contents.should include('  stats  timeout 30s')
-          end
-          it 'should log to an ip address for local0' do
-            contents.should be_any { |match| match =~ /  log  \d+(\.\d+){3} local0/ }
-          end
-          it 'should specify the correct user' do
-            contents.should include('  user  haproxy')
-          end
-          it 'should specify the correct group' do
-            contents.should include('  group  haproxy')
-          end
-          it 'should specify the correct pidfile' do
-            contents.should include('  pidfile  /var/run/haproxy.pid')
-          end
-          it 'should set mode http in default options' do
-            contents.should include('  mode  http')
-          end
-          it 'should not set the global parameter "maxconn"' do
-            contents.should_not include('  maxconn  4000')
-          end
-          it 'should set various options in defaults, removing the "redispatch" option' do
-            contents.should_not include('  option  redispatch')
-            contents.should     include('  option  abortonclose')
-            contents.should     include('  option  logasap')
-            contents.should     include('  option  dontlognull')
-            contents.should     include('  option  httplog')
-            contents.should     include('  option  http-server-close')
-            contents.should     include('  option  forwardfor except 127.0.0.1')
-          end
-          it 'should set timeouts in defaults, removing the "http-request 10s" and "queue 1m" timeout' do
-            contents.should_not include('  timeout  http-request 10s')
-            contents.should_not include('  timeout  queue 1m')
-            contents.should     include('  timeout  connect 5s')
-            contents.should     include('  timeout  check 7s')
-            contents.should     include('  timeout  client 1m')
-            contents.should     include('  timeout  server 1m')
-          end
-        end
-      end
     end
   end
 
+  # Unsupported OSs:
+
   context 'on unsupported operatingsystems' do
+    let(:title) { 'haproxy' }
     let(:facts) do
       { :osfamily => 'windows' }.merge default_facts
     end

--- a/spec/defines/listen_spec.rb
+++ b/spec/defines/listen_spec.rb
@@ -19,7 +19,7 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('croy_listen_block').with(
+    it { should contain_concat__fragment('haproxy-croy_listen_block').with(
       'order'   => '20-croy-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten croy\n  bind 1.1.1.1:18140 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
@@ -38,7 +38,7 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
@@ -54,7 +54,7 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
@@ -70,7 +70,7 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten apache\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
@@ -114,7 +114,7 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten apache\n  bind some-hostname:80 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
@@ -129,7 +129,7 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten apache\n  bind *:80 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
@@ -143,7 +143,7 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten apache\n  bind 10.0.0.1:333 ssl crt public.puppetlabs.com\n  bind 192.168.122.1:8082 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
@@ -200,7 +200,7 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten apache\n  bind 1.1.1.1:80 the options go here\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
@@ -214,7 +214,7 @@ describe 'haproxy::listen' do
       }
     end
 
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten apache\n  bind 1.1.1.1:80 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
@@ -234,10 +234,32 @@ describe 'haproxy::listen' do
         },
       }
     end
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+    ) }
+  end
+  context "when bind parameter is used with ip addresses that sort wrong lexigraphically" do
+    let(:params) do
+      {
+        :name  => 'apache',
+        :bind  => {
+          '10.1.3.21:80'      => 'name input21',
+          '8.252.206.100:80'  => 'name input100',
+          '8.252.206.101:80'  => 'name input101',
+          '8.252.206.99:80'   => 'name input99',
+          '1.1.1.1:80'        => [],
+          ':443,:8443'        => [ 'ssl', 'crt public.puppetlabs.com', 'no-sslv3' ],
+          '2.2.2.2:8000-8010' => [ 'ssl', 'crt public.puppetlabs.com' ],
+          'fd@${FD_APP1}'     => [],
+        },
+      }
+    end
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
+      'order'   => '20-apache-00',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "\nlisten apache\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind 8.252.206.99:80 name input99\n  bind 8.252.206.100:80 name input100\n  bind 8.252.206.101:80 name input101\n  bind 10.1.3.21:80 name input21\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
     ) }
   end
 
@@ -261,7 +283,7 @@ describe 'haproxy::listen' do
         ],
       }
     end
-    it { should contain_concat__fragment('apache_listen_block').with(
+    it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nlisten apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  reqadd X-Forwarded-Proto:\\ https\n  default_backend dev00_webapp\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  bind-process all\n  compression algo gzip\n"

--- a/spec/defines/peer_spec.rb
+++ b/spec/defines/peer_spec.rb
@@ -1,12 +1,19 @@
 require 'spec_helper'
 
 describe 'haproxy::peer' do
+  let :pre_condition do
+  'class{"haproxy":
+      config_file => "/tmp/haproxy.cfg"
+   }
+  '
+  end
   let(:title) { 'dero' }
   let(:facts) do
     {
       :ipaddress      => '1.1.1.1',
       :hostname       => 'dero',
       :concat_basedir => '/foo',
+      :osfamily       => 'RedHat',
     }
   end
 
@@ -18,9 +25,9 @@ describe 'haproxy::peer' do
       }
     end
 
-    it { should contain_concat__fragment('peers-tyler-dero').with(
+    it { should contain_concat__fragment('haproxy-peers-tyler-dero').with(
       'order'   => '30-peers-01-tyler-dero',
-      'target'  => '/etc/haproxy/haproxy.cfg',
+      'target'  => '/tmp/haproxy.cfg',
       'content' => "  peer dero 1.1.1.1:1024\n"
     ) }
   end
@@ -34,7 +41,7 @@ describe 'haproxy::peer' do
       }
     end
 
-    it { should contain_concat__fragment('peers-tyler-dero').with(
+    it { should contain_concat__fragment('haproxy-peers-tyler-dero').with(
       'ensure' => 'absent'
     ) }
   end

--- a/spec/defines/peers_spec.rb
+++ b/spec/defines/peers_spec.rb
@@ -1,17 +1,24 @@
 require 'spec_helper'
 
 describe 'haproxy::peers' do
+  let :pre_condition do
+  'class{"haproxy":
+      config_file => "/tmp/haproxy.cfg"
+   }
+  '
+  end
   let(:facts) {{
     :ipaddress      => '1.1.1.1',
     :concat_basedir => '/foo',
+    :osfamily       => 'RedHat',
   }}
 
   context "when no options are passed" do
     let(:title) { 'bar' }
 
-    it { should contain_concat__fragment('bar_peers_block').with(
+    it { should contain_concat__fragment('haproxy-bar_peers_block').with(
       'order'   => '30-peers-00-bar',
-      'target'  => '/etc/haproxy/haproxy.cfg',
+      'target'  => '/tmp/haproxy.cfg',
       'content' => "\npeers bar\n"
     ) }
   end

--- a/spec/defines/userlist_spec.rb
+++ b/spec/defines/userlist_spec.rb
@@ -26,7 +26,7 @@ describe 'haproxy::userlist' do
       }
     end
 
-    it { should contain_concat__fragment('admins_userlist_block').with(
+    it { should contain_concat__fragment('haproxy-admins_userlist_block').with(
       'order'   => '12-admins-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
       'content' => "\nuserlist admins\n  group superadmins users kitchen scott\n  group megaadmins users kitchen\n  user scott insecure-password elgato\n  user kitchen insecure-password foobar\n"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,23 +1,9 @@
 require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper
 
 UNSUPPORTED_PLATFORMS = ['Darwin', 'Suse','windows','AIX','Solaris']
-
-unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
-  # This will install the latest available package on el and deb based
-  # systems fail on windows and osx, and install via gem on other *nixes
-  foss_opts = {
-    :default_action => 'gem_install',
-    :version        => (ENV['PUPPET_VERSION'] || '3.8.1'),
-  }
-
-  if default.is_pe?; then install_pe; else install_puppet( foss_opts ); end
-
-  hosts.each do |host|
-    on host, "mkdir -p #{host['distmoduledir']}"
-    # Windows doesn't have a hieraconf variable
-    on host, "touch #{host['hieraconf']}" if fact('osfamily') != 'windows'
-  end
-end
 
 RSpec.configure do |c|
   # Project root

--- a/templates/fragments/_bind.erb
+++ b/templates/fragments/_bind.erb
@@ -1,9 +1,17 @@
-<% require 'ipaddr' -%>
-<%- if @bind -%>
-<%- @bind.sort.map do |address_port, bind_params| -%>
-  bind <%= address_port -%> <%= Array(bind_params).join(" ") %>
-<%- end -%>
-<%- else -%>
+<%
+require 'ipaddr'
+if @bind
+  @bind.sort_by { |address_port, bind_params|
+    md = /^((\d+)\.(\d+)\.(\d+)\.(\d+))?(.*)/.match(address_port)
+    [ (md[1] ? md[2..5].inject(0){ |addr, octet| (addr << 8) + octet.to_i } : -1), md[6] ]
+
+  }.map do |address_port, bind_params|
+-%>  bind <%= address_port -%> <%= Array(bind_params).join(" ") %>
+<%
+
+  end
+else
+-%>
 <%-
   Array(@ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port|
   begin

--- a/templates/haproxy-base.cfg.erb
+++ b/templates/haproxy-base.cfg.erb
@@ -1,5 +1,7 @@
 global
-<% @global_options.sort.each do |key,val| -%>
+<% @_global_options.sort.each do |key,val| -%>
+<%# Skip options whose value is undef/nil -%>
+<% next if val == :undef or val.nil? -%>
 <% if val.is_a?(Array) -%>
 <% val.each do |item| -%>
   <%= key %>  <%= item %>
@@ -10,7 +12,9 @@ global
 <% end -%>
 
 defaults
-<% @defaults_options.sort.each do |key,val| -%>
+<% @_defaults_options.sort.each do |key,val| -%>
+<%# Skip options whose value is undef/nil -%>
+<% next if val == :undef or val.nil? -%>
 <% if val.is_a?(Array) -%>
 <% val.each do |item| -%>
   <%= key %>  <%= item %>

--- a/templates/haproxy_backend_block.erb
+++ b/templates/haproxy_backend_block.erb
@@ -1,3 +1,3 @@
 
-backend <%= @name %>
+backend <%= @section_name %>
 <%= scope.function_template(['haproxy/fragments/_options.erb']) -%>

--- a/templates/haproxy_frontend_block.erb
+++ b/templates/haproxy_frontend_block.erb
@@ -1,5 +1,5 @@
 
-frontend <%= @name %>
+frontend <%= @section_name %>
 <%= scope.function_template(['haproxy/fragments/_bind.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_mode.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_options.erb']) -%>

--- a/templates/haproxy_listen_block.erb
+++ b/templates/haproxy_listen_block.erb
@@ -1,5 +1,5 @@
 
-listen <%= @name %>
+listen <%= @section_name %>
 <%= scope.function_template(['haproxy/fragments/_bind.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_mode.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_options.erb']) -%>

--- a/templates/haproxy_userlist_block.erb
+++ b/templates/haproxy_userlist_block.erb
@@ -1,5 +1,5 @@
 
-userlist <%= @name %>
+userlist <%= @section_name %>
 <%- Array(@groups).each do |group| -%>
   <%- if group and ! group.empty? -%>
   group <%= group %>

--- a/templates/instance_service_unit_example.erb
+++ b/templates/instance_service_unit_example.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=HAProxy-<%= @title %> Load Balancer
+After=syslog.target network.target
+
+[Service]
+ExecStart=<%= @wrapper %> -f /etc/haproxy-<%= @title %>/haproxy-<%= @title %>.cfg -p /run/haproxy-<%= @title %>.pid
+ExecReload=/bin/kill -USR2 $MAINPID
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add haproxy::instance for the creation of multiple instances of haproxy on a host.  See [MODULES-1783]

   * New Define Resource Type: haproxy::instance
   * New Define Resource Type: haproxy::instance_service
   * Class[haproxy] is now a wrapper that calls haproxy::instance
   * Add "instance" parameter to all public defines.
   * All private classes become private defined resource types.
   * Pass parameters to private defined resource types rather than
   * "inherts params" no longer used for classes that are now defines
   * Documentation updated, examples added
   * Spec tests updated and new tests added
   * Fixed: mode and options lines include an extra space