### PR TITLE
Remove options sorting

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -52,11 +52,11 @@
 define haproxy::backend (
   $collect_exported = true,
   $options          = {
+    'balance' => 'roundrobin',
     'option'  => [
       'tcplog',
       'ssl-hello-chk'
     ],
-    'balance' => 'roundrobin'
   }
 ) {
 

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -82,11 +82,11 @@ define haproxy::listen (
   $mode                         = undef,
   $collect_exported             = true,
   $options                      = {
+    'balance' => 'roundrobin',
     'option'  => [
       'tcplog',
       'ssl-hello-chk'
     ],
-    'balance' => 'roundrobin'
   },
   # Deprecated
   $bind_options                 = '',

--- a/templates/fragments/_options.erb
+++ b/templates/fragments/_options.erb
@@ -1,4 +1,4 @@
-<% @options.sort.each do |key, val| -%>
+<% @options.each do |key, val| -%>
 <% Array(val).each do |item| -%>
   <%= key %> <%= item %>
 <% end -%>


### PR DESCRIPTION
Jira issue: MODULES-1317

Sorting the options causes parser warnings, and may introduce other unwanted behaviour. Order is significant in HAProxy.