### PR TITLE
No options sort

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -52,11 +52,11 @@
 define haproxy::backend (
   $collect_exported = true,
   $options          = {
+    'balance' => 'roundrobin',
     'option'  => [
       'tcplog',
       'ssl-hello-chk'
     ],
-    'balance' => 'roundrobin'
   }
 ) {
 

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -82,11 +82,11 @@ define haproxy::listen (
   $mode                         = undef,
   $collect_exported             = true,
   $options                      = {
+    'balance' => 'roundrobin',
     'option'  => [
       'tcplog',
       'ssl-hello-chk'
     ],
-    'balance' => 'roundrobin'
   },
   # Deprecated
   $bind_options                 = '',

--- a/spec/defines/backend_spec.rb
+++ b/spec/defines/backend_spec.rb
@@ -16,7 +16,7 @@ describe 'haproxy::backend' do
     it { should contain_concat__fragment('bar_backend_block').with(
       'order'   => '20-bar-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nbackend bar\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nbackend bar\n  option tcplog\n  option ssl-hello-chk\n  balance roundrobin\n"
     ) }
   end
 

--- a/templates/fragments/_options.erb
+++ b/templates/fragments/_options.erb
@@ -1,4 +1,4 @@
-<% @options.sort.each do |key, val| -%>
+<% @options.each do |key, val| -%>
 <% Array(val).each do |item| -%>
   <%= key %> <%= item %>
 <% end -%>


### PR DESCRIPTION
Jira issue: MODULES-1317

Sorting the options causes parser warnings, and may introduce other unwanted behaviour. Order is significant in HAProxy.

If someone could check why TravisCI is failing only on Ruby-1.8.7, that would be great. I can run the Rspec tests locally without errors on CentOS-6 and OS X 10.10.2 .