### PR TITLE
YAML support for the "haproxy::frontend" and "haproxy::backend" defines.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,6 +92,8 @@ class haproxy (
   # Deprecated
   $manage_service   = undef,
   $enable           = undef,
+  $frontend         = {},
+  $backend          = {},
 ) inherits haproxy::params {
 
   if $service_ensure != true and $service_ensure != false {
@@ -124,6 +126,9 @@ class haproxy (
   } else {
     $_service_manage = $service_manage
   }
+
+  create_resources('::haproxy::frontend', $frontend)
+  create_resources('::haproxy::backend', $backend)
 
   if $_package_ensure == 'absent' or $_package_ensure == 'purged' {
     anchor { 'haproxy::begin': }


### PR DESCRIPTION
In the haproxy.yaml I wanted to add something like this:

    haproxy::frontend:
      'https1':
        mode: http
        bind:
          '*:443':
            - 'ssl'
            - 'crt'
            - '/etc/haproxy/certs/dev_environments.pem'
            - 'ciphers'
            - 'ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:!RC4:HIGH:!MD5:!aNULL:!EDH'
        options:
          option:
            - 'forwardfor'
          default_backend: 'localhost'
          reqadd:
            - 'X-Forwarded-Proto:\ https'
            - 'X-secure:\ YES'

    haproxy::backend:
      'phabricator':
        options:
          option:
            - 'forwardfor'
          server: 'phabricator nginx1 check'
          balance: 'roundrobin'
          mode: http

but the frontend and backend defines were not handled as a resource. My humble PR is about to fix this.