### PR TITLE
Implement `options` as array of hashes so order is preserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Using storeconfigs, you can export the `haproxy::balancermember` resources on al
 Sets the backend service's name. Generally, it will be the namevar of the defined resource type. This value appears right after the 'backend' statement in haproxy.cfg
 
 #####`options`
-A hash of options that are inserted into the backend service configuration block.
+A hash or array of options that are inserted into the backend service configuration block. If you need to control exactly the order in which these options will appear in the backend service configuration block supply the options as an array of hashes, where each hash has one key-value pair that represents the option and its value.
 
 #####`collect_exported`
 Enables exported resources from `haproxy::balancermember` to be collected, serving as a form of autodiscovery. Displays as a Boolean and defaults to 'true'.
@@ -300,6 +300,22 @@ haproxy::backend { 'puppet00':
     ],
     'balance' => 'roundrobin',
   },
+}
+```
+
+If option order is important use an array of hashes for the `options` parameter to have the backend options appear in the resulting backend configuration block in the exact order in which they are specified in Puppet:
+
+```puppet
+haproxy::backend { 'puppet00':
+  options => [
+    { 'option'  => [
+        'tcplog',
+        'ssl-hello-chk',
+      ]
+    },
+    { 'balance' => 'roundrobin' },
+    { 'cookie'  => 'C00 insert' },
+  ],
 }
 ```
 
@@ -337,7 +353,7 @@ Sets the mode of operation for the frontend service. Valid values are 'undef', '
 Sets the frontend service's name. Generally, it will be the namevar of the defined resource type. This value appears right after the 'fronted' statement in haproxy.cfg.
 
 #####`options`
-A hash of options that are inserted into the frontend service configuration block.
+A hash or array of options that are inserted into the backend service configuration block. If you need to control exactly the order in which these options will appear in the backend service configuration block supply the options as an array of hashes, where each hash has one key-value pair that represents the option and its value. See Example section right below.
 
 #####`ports`
 Sets the ports to listen on for the address specified in `ipaddress`. Accepts a single, comma-separated string or an array of strings, which may be ports or hyphenated port ranges.
@@ -353,14 +369,33 @@ haproxy::frontend { 'puppet00':
   mode          => 'tcp',
   bind_options  => 'accept-proxy',
   options       => {
-    'option'          => [ 'default_backend', 'puppet_backend00'],
+    'default_backend' => 'puppet_backend00',
     'timeout client'  => '30',
-    'balance'         => 'roundrobin'
     'option'          => [
       'tcplog',
       'accept-invalid-http-request',
     ],
   },
+}
+```
+
+If option order is important use an array of hashes for the `options` parameter to have the frontend options appear in the resulting frontned configuration block in the exact order in which they are specified in Puppet:
+
+```puppet
+haproxy::frontend { 'puppet00':
+  ipaddress     => $::ipaddress,
+  ports         => '18140',
+  mode          => 'tcp',
+  bind_options  => 'accept-proxy',
+  options       => [
+    { 'default_backend' => 'puppet_backend00' },
+    { 'timeout client'  => '30' },
+    { 'option'          => [
+        'tcplog',
+        'accept-invalid-http-request',
+      ],
+    }
+  ],
 }
 ```
 
@@ -405,7 +440,7 @@ Specifies the mode of operation for the listening service. Valid values are 'und
 Sets the listening service's name. Generally, it will be the namevar of the defined resource type. This value appears right after the 'listen' statement in haproxy.cfg.
 
 #####`options`
-A hash of options that are inserted into the listening service configuration block.
+A hash or array of options that are inserted into the backend service configuration block. If you need to control exactly the order in which these options will appear in the backend service configuration block supply the options as an array of hashes, where each hash has one key-value pair that represents the option and its value. See Example sections for backend and frontend above.
 
 #####`ports`
 Sets the ports to listen on for the address specified in `ipaddress`. Accepts a single, comma-separated string or an array of strings, which may be ports or hyphenated port ranges.

--- a/spec/defines/listen_spec.rb
+++ b/spec/defines/listen_spec.rb
@@ -241,4 +241,31 @@ describe 'haproxy::listen' do
     ) }
   end
 
+  context "when listen options are specified as an array of hashes" do
+    let(:params) do
+      {
+        :name => 'apache',
+        :bind => {
+          '0.0.0.0:48001-48003' => [],
+        },
+        :mode => 'http',
+        :options => [
+          { 'reqadd'                 => 'X-Forwarded-Proto:\ https' },
+          { 'default_backend'        => 'dev00_webapp' },
+          { 'capture request header' => [ 'X-Forwarded-For len 50', 'Host len 15', 'Referrer len 15' ] },
+          { 'acl'                    => [ 'dst_dev01 dst_port 48001', 'dst_dev02 dst_port 48002', 'dst_dev03 dst_port 48003' ] },
+          { 'use_backend'            => [ 'dev01_webapp if dst_dev01', 'dev02_webapp if dst_dev02', 'dev03_webapp if dst_dev03' ] },
+          { 'option'                 => [ 'httplog', 'http-server-close', 'forwardfor except 127.0.0.1' ] },
+          { 'compression'            => 'algo gzip',
+            'bind-process'           => 'all' }
+        ],
+      }
+    end
+    it { should contain_concat__fragment('apache_listen_block').with(
+      'order'   => '20-apache-00',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "\nlisten apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  reqadd X-Forwarded-Proto:\\ https\n  default_backend dev00_webapp\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  bind-process all\n  compression algo gzip\n"
+    ) }
+  end
+
 end

--- a/templates/fragments/_options.erb
+++ b/templates/fragments/_options.erb
@@ -1,5 +1,19 @@
+<% if @options.is_a?(Hash) -%>
 <% @options.sort.each do |key, val| -%>
 <% Array(val).each do |item| -%>
   <%= key %> <%= item %>
+<% end -%>
+<% end -%>
+<% elsif @options.is_a?(Array) -%>
+<%# Iterate over array elements; each element is a hash (containing key-value -%>
+<%# pairs); in case a hash contains more than one key-value pair the hash is -%>
+<%# sorted by key name before outputting the key name (= option name) and its -%>
+<%# value (or values, one per line) -%>
+<% @options.each do |option| -%>
+<% option.sort.map do |key, val| -%>
+<% Array(val).each do |item| -%>
+  <%= key %> <%= item %>
+<% end -%>
+<% end -%>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Fixes https://tickets.puppetlabs.com/browse/MODULES-1317. See also the
discussion in PR #171.

Frontend, backend and listen options are specified via the
`haproxy::frontend::options`, `haproxy:backend::options` and
`haproxy::listen::options` parameters. Until now this `options`
parameter was a hash, which means it had to be sorted before processing
it in the `_options.erb` template fragment (since Ruby 1.8.x has
non-deterministic hash key ordering).

This clashes with the fact that in HAProxy's configuration order matters.

With this change we allow the `options` parameter to be either a hash,
like before, or an array of hashes, where each hash represents a
frontend, backend or listen option and its value. This way the order in
which options will appear in the final configuration file can be
controlled entirely by the user.

This change is completely backwards compatible and contains updated spec
tests and documentation.