### PR TITLE
Adds documentation to peer and peers resource types

### DIFF
--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -1,3 +1,38 @@
+# == Define Resource Type: haproxy::peer
+#
+# This type will set up a peer entry inside the peers configuration block in
+# /etc/haproxy/haproxy.cfg on the load balancer. Currently, it has the ability to
+# specify the instance name, ip address, ports and server_names.
+#
+# Automatic discovery of peer nodes may be implemented by exporting the peer resource
+# for all HAProxy balancer servers that are configured in the same HA block and
+# then collecting them on all load balancers.
+#
+# === Parameters:
+#
+# [*peers_name*]
+#  Specifies the peer in which this load balancer needs to be added.
+#
+# [*server_names*]
+#  Sets the name of the peer server in the peers configuration block.
+#   Defaults to the hostname. Can be an array. If this parameter is
+#   specified as an array, it must be the same length as the
+#   ipaddresses parameter's array. A peer is created for each pair
+#   of server\_names and ipaddresses in the array.
+#
+# [*ensure*]
+#  Whether to add or remove the peer. Defaults to 'present'.
+#   Valid values are 'present' and 'absent'.
+#
+# [*ipaddresses*]
+#  Specifies the IP address used to contact the peer member server.
+#   Can be an array. If this parameter is specified as an array it
+#   must be the same length as the server\_names parameter's array.
+#   A peer is created for each pair of address and server_name.
+#
+# [*ports*]
+#  Sets the port on which the peer is going to share the state.
+
 define haproxy::peer (
   $peers_name,
   $port,

--- a/manifests/peers.pp
+++ b/manifests/peers.pp
@@ -1,3 +1,17 @@
+# == Defined Type: haproxy::peers
+#
+#  This type will set up a peers entry in /etc/haproxy/haproxy.cfg
+#   on the load balancer. This setting is required to share the
+#   current state of HAproxy with other HAproxy in High available
+#   configurations.
+#
+# === Parameters
+#
+# [*name*]
+#  Sets the peers' name. Generally it will be the namevar of the
+#   defined resource type. This value appears right after the
+#   'peers' statement in haproxy.cfg
+
 define haproxy::peers (
   $collect_exported = true,
 ) {


### PR DESCRIPTION
Adds basic documentation to haproxy::peer and haproxy::peers resource types to clean couple puppet-lint warnings that these types are not documented