### PR TITLE
Handle /etc/default/haproxy better, do not damage other content.

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,9 +6,13 @@ class haproxy::service inherits haproxy {
 
   if $haproxy::_service_manage {
     if ($::osfamily == 'Debian') {
-      file { '/etc/default/haproxy':
-        content => 'ENABLED=1',
-        before  => Service['haproxy'],
+      # Enable the service, but do not blow away any other config
+      file_line { '/etc/default/haproxy,ENABLED':
+        ensure => 'present',
+        path   => '/etc/default/haproxy',
+        line   => 'ENABLED=1',
+        match  => '^ENABLED=',
+        before => Service['haproxy'],
       }
     }
 


### PR DESCRIPTION
I have other environment variables set in /etc/default/haproxy, that I use via the env construct in the haproxy 
config file. This ensures the other settings do not get mangled.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>