### PR TITLE
prevent warning on puppet 4

### DIFF
--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -77,7 +77,7 @@ define haproxy::frontend (
     ],
   },
   # Deprecated
-  $bind_options     = '',
+  $bind_options     = undef,
 ) {
 
   if $ports and $bind {


### PR DESCRIPTION
Puppet 4 evaluates the bind_options empty string value as `true` where this would be `false` in Puppet 3 which causes puppet 4 to throw a warning. This change prevents warnings in Puppet 4 by setting the value as `undef`.