### PR TITLE
Update examples to use seconds (default is ms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ haproxy::frontend { 'puppet00':
   bind_options  => 'accept-proxy',
   options       => {
     'default_backend' => 'puppet_backend00',
-    'timeout client'  => '30',
+    'timeout client'  => '30s',
     'option'          => [
       'tcplog',
       'accept-invalid-http-request',
@@ -228,7 +228,7 @@ haproxy::frontend { 'puppet00':
   bind_options  => 'accept-proxy',
   options       => [
     { 'default_backend' => 'puppet_backend00' },
-    { 'timeout client'  => '30' },
+    { 'timeout client'  => '30s' },
     { 'option'          => [
         'tcplog',
         'accept-invalid-http-request',

--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -56,7 +56,7 @@
 #        'tcplog',
 #        'accept-invalid-http-request',
 #      ],
-#      'timeout client' => '30',
+#      'timeout client' => '30s',
 #      'balance'    => 'roundrobin'
 #    },
 #  }


### PR DESCRIPTION
relates to https://tickets.puppetlabs.com/browse/MODULES-2431
:unamused: - the value specified for 'timeout client' is in ms if unit suffix is not provided:
https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-timeout%20client

(:joy: this took me forever to figure out why ssl connections failed...)