### PR TITLE
Deep merge global and default options with user-supplied options

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ class { 'haproxy':
   defaults_options => {
     'log'     => 'global',
     'stats'   => 'enable',
-    'option'  => 'redispatch',
+    'option'  => [
+      'redispatch',
+    ],
     'retries' => '3',
     'timeout' => [
       'http-request 10s',
@@ -89,6 +91,30 @@ class { 'haproxy':
       'check 10s',
     ],
     'maxconn' => '8000',
+  },
+}
+~~~
+
+The above shown values are the module's defaults for platforms like Debian and RedHat (see `haproxy::params` for details). If you wish to override any of these defaults set `global_options` and/or `defaults_options` to a hash containing just the `option => value` pairs you need changed. Note that array values that are present in both the default hash and your supplied hash are concatenated and duplicate items removed:
+
+~~~puppet
+class { 'haproxy':
+  global_options   => {
+    'user'    => 'root',
+    'group'   => 'root',
+    'stats'   => [
+      'socket /var/lib/haproxy/stats',
+      'timeout 30s'
+    ]
+  },
+  defaults_options => {
+    'retries' => '5',
+    'timeout' => [
+      'http-request 7s',
+      'connect 3s',
+      'check 9s',
+    ],
+    'maxconn' => '15000',
   },
 }
 ~~~
@@ -314,38 +340,66 @@ Main class, includes all other classes.
 
 * `defaults_options`: Configures all the default HAProxy options at once. Valid options: a hash of `option => value` pairs. To set an option multiple times (e.g. multiple 'timeout' or 'stats' values) pass its value as an array. Each element in your array results in a separate instance of the option, on a separate line in haproxy.cfg. Default:
 
-~~~puppet
-{
-        'log'     => 'global',
-        'stats'   => 'enable',
-        'option'  => 'redispatch',
-        'retries' => '3',
-        'timeout' => [
-          'http-request 10s',
-          'queue 1m',
-          'connect 10s',
-          'client 1m',
-          'server 1m',
-          'check 10s',
-        ],
-        'maxconn' => '8000'
-}
-~~~
+  ~~~puppet
+  {
+          'log'     => 'global',
+          'stats'   => 'enable',
+          'option'  => [
+            'redispatch',
+          ],
+          'retries' => '3',
+          'timeout' => [
+            'http-request 10s',
+            'queue 1m',
+            'connect 10s',
+            'client 1m',
+            'server 1m',
+            'check 10s',
+          ],
+          'maxconn' => '8000'
+  }
+  ~~~
+
+  To override any of these default values you don't have to recreate and supply the whole hash, just set `defaults_options` to a hash of the `option => value` pairs you'd like to override. Note that array values that are present in both the default hash and your supplied hash are concatenated and duplicate items removed. Example:
+
+  ~~~puppet
+  {
+          'retries' => '5',
+          'timeout' => [
+            'http-request 7s',
+            'connect 5s',
+          ],
+          'maxconn' => '12000'
+  }
+  ~~~
 
 * `global_options`: Configures all the global HAProxy options at once. Valid options: a hash of `option => value` pairs. To set an option multiple times (e.g. multiple 'timeout' or 'stats' values) pass its value as an array. Each element in your array results in a separate instance of the option, on a separate line in haproxy.cfg. Default:
 
-~~~puppet
-{
-        'log'     => "${::ipaddress} local0",
-        'chroot'  => '/var/lib/haproxy',
-        'pidfile' => '/var/run/haproxy.pid',
-        'maxconn' => '4000',
-        'user'    => 'haproxy',
-        'group'   => 'haproxy',
-        'daemon'  => '',
-        'stats'   => 'socket /var/lib/haproxy/stats'
-}
-~~~
+  ~~~puppet
+  {
+          'log'     => "${::ipaddress} local0",
+          'chroot'  => '/var/lib/haproxy',
+          'pidfile' => '/var/run/haproxy.pid',
+          'maxconn' => '4000',
+          'user'    => 'haproxy',
+          'group'   => 'haproxy',
+          'daemon'  => '',
+          'stats'   => 'socket /var/lib/haproxy/stats'
+  }
+  ~~~
+
+  To override any of these default values you don't have to recreate and supply the whole hash, just set `global_options` to a hash of the `option => value` pairs you'd like to override. Note that array values that are present in both the default hash and your supplied hash are concatenated and duplicate items removed. Example:
+
+  ~~~puppet
+  {
+          'user'  => 'root',
+          'group' => 'root',
+          'stats' => [
+            'socket /var/lib/haproxy/admin.sock mode 660 level admin',
+            'timeout 30s',
+          ]
+  }
+  ~~~
 
 * `package_ensure`: Specifies whether the HAProxy package should exist. Defaults to 'present'. Valid options: 'present' and 'absent'. Default: 'present'.
 

--- a/lib/puppet/parser/functions/haproxy_deep_merge.rb
+++ b/lib/puppet/parser/functions/haproxy_deep_merge.rb
@@ -1,0 +1,49 @@
+module Puppet::Parser::Functions
+  newfunction(:haproxy_deep_merge, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+    Recursively merges two or more hashes together and returns the resulting hash.
+
+    For example:
+
+        $hash1 = {'one' => 1, 'two' => 2, 'three' => { 'four' => 4 }, 'six' => [ 'έξι', 'sechs', 'zes' ] }
+        $hash2 = {'two' => 'dos', 'three' => { 'five' => 5 }, 'six' => [ 'sechs', 'seis' ] }
+        $merged_hash = haproxy_deep_merge($hash1, $hash2)
+        # The resulting hash is equivalent to:
+        # $merged_hash = { 'one' => 1, 'two' => 'dos', 'three' => { 'four' => 4, 'five' => 5 }, 'six' => [ 'έξι', 'sechs', 'zes', 'seis' ] }
+
+    When there is a duplicate key that is a hash, they are recursively merged.
+    When there is a duplicate key that is an array, they are concatenated and duplicate items removed.
+    When there is a duplicate key that is not a hash and not an array, the key in the rightmost hash will "win."
+
+    Note: This function is copied from puppetlabs-stdlib, renamed
+    haproxy_deep_merge() and extended to support merging array values.
+    ENDHEREDOC
+
+    if args.length < 2
+      raise Puppet::ParseError, ("haproxy_deep_merge(): wrong number of arguments (#{args.length}; must be at least 2)")
+    end
+
+    haproxy_deep_merge = Proc.new do |hash1,hash2|
+      hash1.merge(hash2) do |key,old_value,new_value|
+        if old_value.is_a?(Hash) && new_value.is_a?(Hash)
+          haproxy_deep_merge.call(old_value, new_value)
+        elsif old_value.is_a?(Array) && new_value.is_a?(Array)
+          (old_value + new_value).uniq
+        else
+          new_value
+        end
+      end
+    end
+
+    result = Hash.new
+    args.each do |arg|
+      next if arg.is_a? String and arg.empty? # empty string is synonym for puppet's undef
+      # If the argument was not a hash, skip it.
+      unless arg.is_a?(Hash)
+        raise Puppet::ParseError, "haproxy_deep_merge: unexpected argument type #{arg.class}, only expects hash arguments"
+      end
+
+      result = haproxy_deep_merge.call(result, arg)
+    end
+    return( result )
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,9 @@ class haproxy::config inherits haproxy {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
+  $global_options_merged   = haproxy_deep_merge($haproxy::params::global_options, $haproxy::global_options)
+  $defaults_options_merged = haproxy_deep_merge($haproxy::params::defaults_options, $haproxy::defaults_options)
+
   concat { $haproxy::config_file:
     owner => '0',
     group => '0',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class haproxy::params {
       $defaults_options = {
         'log'     => 'global',
         'stats'   => 'enable',
-        'option'  => 'redispatch',
+        'option'  => [ 'redispatch' ],
         'retries' => '3',
         'timeout' => [
           'http-request 10s',

--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -342,7 +342,91 @@ describe 'haproxy', :type => :class do
           { :osfamily => 'Gentoo' }.merge default_facts
         end
       end
+    end
 
+    describe 'when deep-merging global and defaults options' do
+      # For testing the deep-merging functionality we restrict ourselves to
+      # Debian OS family so that we don't have to juggle different sets of
+      # global_options and defaults_options (like for FreeBSD).
+      ['Debian' ].each do |osfamily|
+        context "on #{osfamily} family operatingsystems" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:contents) { param_value(catalogue, 'concat::fragment', 'haproxy-base', 'content').split("\n") }
+          let(:params) do
+            {
+              'global_options'  => {
+                'log-send-hostname' => '',
+                'stats'             => [
+                  'socket /var/lib/haproxy/admin.sock mode 660 level admin',
+                  'timeout 30s'
+                ]
+              },
+              'defaults_options' => {
+                'mode'    => 'http',
+                'option'  => [
+                  'abortonclose',
+                  'logasap',
+                  'dontlognull',
+                  'httplog',
+                  'http-server-close',
+                  'forwardfor except 127.0.0.1',
+                ],
+                'timeout' => [
+                  'connect 5s',
+                  'client 1m',
+                  'server 1m',
+                  'check 7s',
+                ]
+              },
+            }
+          end
+          it 'should contain global and defaults sections' do
+            contents.should include('global')
+            contents.should include('defaults')
+          end
+          it 'should send hostname with log in global options' do
+            contents.should include('  log-send-hostname  ')
+          end
+          it 'should enable admin stats and stats timeout in global options' do
+            contents.should include('  stats  socket /var/lib/haproxy/admin.sock mode 660 level admin')
+            contents.should include('  stats  timeout 30s')
+          end
+          it 'should log to an ip address for local0' do
+            contents.should be_any { |match| match =~ /  log  \d+(\.\d+){3} local0/ }
+          end
+          it 'should specify the correct user' do
+            contents.should include('  user  haproxy')
+          end
+          it 'should specify the correct group' do
+            contents.should include('  group  haproxy')
+          end
+          it 'should specify the correct pidfile' do
+            contents.should include('  pidfile  /var/run/haproxy.pid')
+          end
+          it 'should set mode http in default options' do
+            contents.should include('  mode  http')
+          end
+          it 'should set various options in defaults, including unchanged "redispatch"' do
+            contents.should include('  option  abortonclose')
+            contents.should include('  option  redispatch')
+            contents.should include('  option  logasap')
+            contents.should include('  option  dontlognull')
+            contents.should include('  option  httplog')
+            contents.should include('  option  http-server-close')
+            contents.should include('  option  forwardfor except 127.0.0.1')
+          end
+          it 'should set timeouts in defaults, including unchanged "http-request 10s"' do
+            contents.should include('  timeout  connect 5s')
+            contents.should include('  timeout  http-request 10s')
+            contents.should include('  timeout  queue 1m')
+            contents.should include('  timeout  check 7s')
+            contents.should include('  timeout  client 1m')
+            contents.should include('  timeout  server 1m')
+          end
+        end
+      end
     end
   end
 
@@ -356,4 +440,6 @@ describe 'haproxy', :type => :class do
       }.to raise_error(Puppet::Error, /operating system is not supported with the haproxy module/)
     end
   end
+
+
 end

--- a/templates/haproxy-base.cfg.erb
+++ b/templates/haproxy-base.cfg.erb
@@ -1,5 +1,7 @@
 global
-<% @global_options.sort.each do |key,val| -%>
+<% @global_options_merged.sort.each do |key,val| -%>
+<%# Skip options whose value is the special string "absent" -%>
+<% next if val == 'absent' -%>
 <% if val.is_a?(Array) -%>
 <% val.each do |item| -%>
   <%= key %>  <%= item %>
@@ -10,7 +12,9 @@ global
 <% end -%>
 
 defaults
-<% @defaults_options.sort.each do |key,val| -%>
+<% @defaults_options_merged.sort.each do |key,val| -%>
+<%# Skip options whose value is the special string "absent" -%>
+<% next if val == 'absent' -%>
 <% if val.is_a?(Array) -%>
 <% val.each do |item| -%>
   <%= key %>  <%= item %>


### PR DESCRIPTION
This way one can override or add arbitrary keys and values to the
`global_options` and `defaults_options` hashes without having to reproduce
the whole hash.

This is done by deep merging the default hashes for `global_options` and
`defaults_options` specified in `haproxy::params` with their pendants
specified as the class parameters. For array values that are present in
both a default hash and a user-supplied hash the arrays are concatenated
and duplicates removed.

Because of the need for deep merging the `deep_merge()` function from
puppetlabs-stdlib 4.2.0 is copied here, renamed `haproxy_deep_merge()`
and extended to support merging array values

Contains updated spec tests and documentation.

Discussed in PR #121.