### PR TITLE
Remove ssl-hello-chk from default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ haproxy::listen { 'puppet00':
   options   => {
     'option'  => [
       'tcplog',
-      'ssl-hello-chk',
     ],
     'balance' => 'roundrobin',
   },
@@ -155,7 +154,6 @@ haproxy::listen { 'puppet00':
   options => {
     'option'  => [
       'tcplog',
-      'ssl-hello-chk',
     ],
     'balance' => 'roundrobin',
   },
@@ -280,7 +278,6 @@ haproxy::backend { 'puppet00':
   options => {
     'option'  => [
       'tcplog',
-      'ssl-hello-chk',
     ],
     'balance' => 'roundrobin',
   },
@@ -294,7 +291,6 @@ haproxy::backend { 'puppet00':
   options => [
     { 'option'  => [
         'tcplog',
-        'ssl-hello-chk',
       ]
     },
     { 'balance' => 'roundrobin' },

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -50,7 +50,6 @@ haproxy::listen { 'puppet00':
   options   => {
     'option'  => [
       'tcplog',
-      'ssl-hello-chk',
     ],
     'balance' => 'roundrobin',
   },

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -54,7 +54,6 @@ define haproxy::backend (
   $options          = {
     'option'  => [
       'tcplog',
-      'ssl-hello-chk'
     ],
     'balance' => 'roundrobin'
   },

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -84,7 +84,6 @@ define haproxy::listen (
   $options                      = {
     'option'  => [
       'tcplog',
-      'ssl-hello-chk'
     ],
     'balance' => 'roundrobin'
   },

--- a/spec/defines/backend_spec.rb
+++ b/spec/defines/backend_spec.rb
@@ -16,7 +16,7 @@ describe 'haproxy::backend' do
     it { should contain_concat__fragment('haproxy-bar_backend_block').with(
       'order'   => '20-bar-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nbackend bar\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nbackend bar\n  balance roundrobin\n  option tcplog\n"
     ) }
   end
 

--- a/spec/defines/listen_spec.rb
+++ b/spec/defines/listen_spec.rb
@@ -22,7 +22,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-croy_listen_block').with(
       'order'   => '20-croy-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten croy\n  bind 1.1.1.1:18140 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten croy\n  bind 1.1.1.1:18140 \n  balance roundrobin\n  option tcplog\n"
     ) }
   end
   # C9940
@@ -41,7 +41,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  balance roundrobin\n  option tcplog\n"
     ) }
   end
   # C9940
@@ -57,7 +57,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind 23.23.23.23:80 \n  bind 23.23.23.23:443 \n  balance roundrobin\n  option tcplog\n"
     ) }
   end
   # C9962
@@ -73,7 +73,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  balance roundrobin\n  option tcplog\n"
     ) }
   end
   # C9963
@@ -117,7 +117,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind some-hostname:80 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind some-hostname:80 \n  balance roundrobin\n  option tcplog\n"
     ) }
   end
   context "when a * is passed for ip address" do
@@ -132,7 +132,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind *:80 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind *:80 \n  balance roundrobin\n  option tcplog\n"
     ) }
   end
   context "when a bind parameter hash is passed" do
@@ -146,7 +146,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind 10.0.0.1:333 ssl crt public.puppetlabs.com\n  bind 192.168.122.1:8082 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind 10.0.0.1:333 ssl crt public.puppetlabs.com\n  bind 192.168.122.1:8082 \n  balance roundrobin\n  option tcplog\n"
     ) }
   end
   context "when a ports parameter and a bind parameter are passed" do
@@ -203,7 +203,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind 1.1.1.1:80 the options go here\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind 1.1.1.1:80 the options go here\n  balance roundrobin\n  option tcplog\n"
     ) }
   end
   context "when bind parameter is used without ipaddress parameter" do
@@ -217,7 +217,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind 1.1.1.1:80 \n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind 1.1.1.1:80 \n  balance roundrobin\n  option tcplog\n"
     ) }
   end
 
@@ -237,7 +237,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  balance roundrobin\n  option tcplog\n"
     ) }
   end
   context "when bind parameter is used with ip addresses that sort wrong lexigraphically" do
@@ -259,7 +259,7 @@ describe 'haproxy::listen' do
     it { should contain_concat__fragment('haproxy-apache_listen_block').with(
       'order'   => '20-apache-00',
       'target'  => '/etc/haproxy/haproxy.cfg',
-      'content' => "\nlisten apache\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind 8.252.206.99:80 name input99\n  bind 8.252.206.100:80 name input100\n  bind 8.252.206.101:80 name input101\n  bind 10.1.3.21:80 name input21\n  balance roundrobin\n  option tcplog\n  option ssl-hello-chk\n"
+      'content' => "\nlisten apache\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind 8.252.206.99:80 name input99\n  bind 8.252.206.100:80 name input100\n  bind 8.252.206.101:80 name input101\n  bind 10.1.3.21:80 name input21\n  balance roundrobin\n  option tcplog\n"
     ) }
   end
 


### PR DESCRIPTION
Most distros are still shipping Haproxy 1.5.x which
performs an SSL HELLO check with SSLv3, which is disabled
on most services due to BEAST and POODLE vulnerabilities.
This causes connection failures that new users will find hard to debug.
For example, setting up a simple set of load-balanced compile masters
in Puppet Enterprise 2015.2.x will fail since PE does not allow
SSLv3.