### PR TITLE
(MODULES-2704) Consistent use of ::haproxy::config_file

### DIFF
--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -1,7 +1,7 @@
 # == Define Resource Type: haproxy::peer
 #
 # This type will set up a peer entry inside the peers configuration block in
-# /etc/haproxy/haproxy.cfg on the load balancer. Currently, it has the ability to
+# haproxy.cfg on the load balancer. Currently, it has the ability to
 # specify the instance name, ip address, ports and server_names.
 #
 # Automatic discovery of peer nodes may be implemented by exporting the peer resource
@@ -45,7 +45,7 @@ define haproxy::peer (
   concat::fragment { "peers-${peers_name}-${name}":
     ensure  => $ensure,
     order   => "30-peers-01-${peers_name}-${name}",
-    target  => '/etc/haproxy/haproxy.cfg',
+    target  => $::haproxy::config_file,
     content => template('haproxy/haproxy_peer.erb'),
   }
 }

--- a/manifests/peers.pp
+++ b/manifests/peers.pp
@@ -1,6 +1,6 @@
 # == Defined Type: haproxy::peers
 #
-#  This type will set up a peers entry in /etc/haproxy/haproxy.cfg
+#  This type will set up a peers entry in haproxy.cfg
 #   on the load balancer. This setting is required to share the
 #   current state of HAproxy with other HAproxy in High available
 #   configurations.
@@ -19,7 +19,7 @@ define haproxy::peers (
   # Template uses: $name, $ipaddress, $ports, $options
   concat::fragment { "${name}_peers_block":
     order   => "30-peers-00-${name}",
-    target  => '/etc/haproxy/haproxy.cfg',
+    target  => $::haproxy::config_file,
     content => template('haproxy/haproxy_peers_block.erb'),
   }
 

--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -109,6 +109,23 @@ describe 'haproxy', :type => :class do
             end
           end
         end
+        context "on #{osfamily} family operatingsystems with setting haproxy.cfg location" do
+          let(:facts) do
+            { :osfamily => osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'config_file' => '/tmp/haproxy.cfg',
+            }
+          end
+          it 'should set up /tmp/haproxy.cfg as a concat resource' do
+            subject.should contain_concat('/tmp/haproxy.cfg').with(
+              'owner' => '0',
+              'group' => '0',
+              'mode'  => '0644'
+            )
+          end
+        end
         context "on #{osfamily} family operatingsystems without managing the service" do
           let(:facts) do
             { :osfamily => osfamily }.merge default_facts

--- a/spec/defines/peer_spec.rb
+++ b/spec/defines/peer_spec.rb
@@ -1,12 +1,19 @@
 require 'spec_helper'
 
 describe 'haproxy::peer' do
+  let :pre_condition do
+  'class{"haproxy":
+      config_file => "/tmp/haproxy.cfg"
+   }
+  '
+  end
   let(:title) { 'dero' }
   let(:facts) do
     {
       :ipaddress      => '1.1.1.1',
       :hostname       => 'dero',
       :concat_basedir => '/foo',
+      :osfamily       => 'RedHat',
     }
   end
 
@@ -20,7 +27,7 @@ describe 'haproxy::peer' do
 
     it { should contain_concat__fragment('peers-tyler-dero').with(
       'order'   => '30-peers-01-tyler-dero',
-      'target'  => '/etc/haproxy/haproxy.cfg',
+      'target'  => '/tmp/haproxy.cfg',
       'content' => "  peer dero 1.1.1.1:1024\n"
     ) }
   end

--- a/spec/defines/peers_spec.rb
+++ b/spec/defines/peers_spec.rb
@@ -1,9 +1,16 @@
 require 'spec_helper'
 
 describe 'haproxy::peers' do
+  let :pre_condition do
+  'class{"haproxy":
+      config_file => "/tmp/haproxy.cfg"
+   }
+  '
+  end
   let(:facts) {{
     :ipaddress      => '1.1.1.1',
     :concat_basedir => '/foo',
+    :osfamily       => 'RedHat',
   }}
 
   context "when no options are passed" do
@@ -11,7 +18,7 @@ describe 'haproxy::peers' do
 
     it { should contain_concat__fragment('bar_peers_block').with(
       'order'   => '30-peers-00-bar',
-      'target'  => '/etc/haproxy/haproxy.cfg',
+      'target'  => '/tmp/haproxy.cfg',
       'content' => "\npeers bar\n"
     ) }
   end


### PR DESCRIPTION
Previously

```puppet
haproxy{'whatever':
  config_file => /tmp/haproxy.cfg
}
haproxy::peers{'mypeers':}
haproxy::peer{'peerA':
   peers_name    => 'mypeers',
   port                 => 5000,
   ipaddresses    => ['1.2.3.4','5.6.7.8],
   server_names => ['a.example.org','b.example.org']
}
```
would fail since haproxy:peer and peers were
hardcoded to use */etc/haproxy/haproxy.cfg*

haproxy::config_file is now respected consistently
throughout the module.

https://tickets.puppetlabs.com/browse/MODULES-2704