### PR TITLE
Merge global and default options with user-supplied options

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,15 @@ class haproxy::config inherits haproxy {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
+  if $haproxy::merge_options {
+    $_global_options   = merge($haproxy::params::global_options, $haproxy::global_options)
+    $_defaults_options = merge($haproxy::params::defaults_options, $haproxy::defaults_options)
+  } else {
+    $_global_options   = $haproxy::global_options
+    $_defaults_options = $haproxy::defaults_options
+    warning("${module_name}: The \$merge_options parameter will default to true in the next major release. Please review the documentation regarding the implications.")
+  }
+
   concat { $haproxy::config_file:
     owner => '0',
     group => '0',
@@ -24,11 +33,11 @@ class haproxy::config inherits haproxy {
     content => template('haproxy/haproxy-base.cfg.erb'),
   }
 
-  if $haproxy::global_options['chroot'] {
-    file { $haproxy::global_options['chroot']:
+  if $_global_options['chroot'] {
+    file { $_global_options['chroot']:
       ensure => directory,
-      owner  => $haproxy::global_options['user'],
-      group  => $haproxy::global_options['group'],
+      owner  => $_global_options['user'],
+      group  => $_global_options['group'],
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,12 @@
 #    options as an array and you will get a line for each of them in the
 #    resultant haproxy.cfg file.
 #
+# [*merge_options*]
+#   Whether to merge the user-supplied `global_options`/`defaults_options`
+#   hashes with their default values set in params.pp. Merging allows to change
+#   or add options without having to recreate the entire hash. Defaults to
+#   false, but will default to true in future releases.
+#
 #[*restart_command*]
 #   Command to use when restarting the on config changes.
 #    Passed directly as the <code>'restart'</code> parameter to the service resource.
@@ -89,6 +95,7 @@ class haproxy (
   $service_options  = "ENABLED=1\n",
   $global_options   = $haproxy::params::global_options,
   $defaults_options = $haproxy::params::defaults_options,
+  $merge_options    = $haproxy::params::merge_options,
   $restart_command  = undef,
   $custom_fragment  = undef,
   $config_file      = $haproxy::params::config_file,
@@ -105,6 +112,7 @@ class haproxy (
   }
   validate_string($package_name,$package_ensure)
   validate_bool($service_manage)
+  validate_bool($merge_options)
   validate_string($service_options)
 
   # To support deprecating $enable

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,9 @@
 #  extended by changing package names and configuration file paths.
 #
 class haproxy::params {
+  # XXX: This will change to true in the next major release
+  $merge_options = false
+
   case $::osfamily {
     'Archlinux', 'Debian', 'Redhat', 'Gentoo', 'Suse' : {
       $package_name     = 'haproxy'
@@ -21,7 +24,7 @@ class haproxy::params {
       $defaults_options = {
         'log'     => 'global',
         'stats'   => 'enable',
-        'option'  => 'redispatch',
+        'option'  => [ 'redispatch' ],
         'retries' => '3',
         'timeout' => [
           'http-request 10s',

--- a/templates/haproxy-base.cfg.erb
+++ b/templates/haproxy-base.cfg.erb
@@ -1,5 +1,7 @@
 global
-<% @global_options.sort.each do |key,val| -%>
+<% @_global_options.sort.each do |key,val| -%>
+<%# Skip options whose value is undef/nil -%>
+<% next if val == :undef or val.nil? -%>
 <% if val.is_a?(Array) -%>
 <% val.each do |item| -%>
   <%= key %>  <%= item %>
@@ -10,7 +12,9 @@ global
 <% end -%>
 
 defaults
-<% @defaults_options.sort.each do |key,val| -%>
+<% @_defaults_options.sort.each do |key,val| -%>
+<%# Skip options whose value is undef/nil -%>
+<% next if val == :undef or val.nil? -%>
 <% if val.is_a?(Array) -%>
 <% val.each do |item| -%>
   <%= key %>  <%= item %>


### PR DESCRIPTION
This way one can override or add arbitrary keys and values to the
`global_options` and `defaults_options` hashes without having to reproduce
the whole hash.

This is done by merging the default hashes for `global_options` and
`defaults_options` specified in `haproxy::params` with their pendants
specified as the class parameters. Values supplied by the user will
"win" over any default values from `haproxy::params`. Uses the `merge()`
function from puppetlabs-stdlib.

Also allows "unsetting" default values from `haproxy::params` by using
the special value `absent`. Parameters set thus will not appear in the
resulting configuration file.

Contains updated spec tests and documentation.

Discussed in PR #121.