### PR TITLE
Add support for managing map files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     * [Set up a frontend service](#set-up-a-frontend-service)
     * [Set up a backend service](#set-up-a-backend-service)
     * [Configure multiple haproxy instances on one machine](#configure-multiple-haproxy-instances-on-one-machine)
+    * [Manage a map file](#manage-a-map-file)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 6. [Limitations - OS compatibility, etc.](#limitations)
 7. [Development - Guide for contributing to the module](#development)
@@ -380,6 +381,44 @@ The second uses a custom package.
      ipaddress        => $::ipaddress,
      ports            => '9900',
    }
+
+### Manage a map file
+
+~~~puppet
+haproxy::mapfile { 'domains-to-backends':
+  ensure   => 'present',
+  mappings => [
+    { 'app01.example.com' => 'bk_app01' },
+    { 'app02.example.com' => 'bk_app02' },
+    { 'app03.example.com' => 'bk_app03' },
+    { 'app04.example.com' => 'bk_app04' },
+    'app05.example.com bk_app05',
+    'app06.example.com bk_app06',
+  ],
+}
+~~~
+
+This creates a file `/etc/haproxy/domains-to-backends.map` containing the mappings specified in the `mappings` array.
+
+The map file can then be used in a frontend to map `Host:` values to backends, implementing name-based virtual hosting:
+
+```
+frontend ft_allapps
+  [...]
+  use_backend %[req.hdr(host),lower,map(/etc/haproxy/domains-to-backends.map,bk_default)]
+```
+
+Or expressed using `haproxy::frontend`:
+
+~~~puppet
+haproxy::frontend { 'ft_allapps':
+  ipaddress => '0.0.0.0',
+  ports     => '80',
+  mode      => 'http',
+  options   => {
+    'use_backend' => '%[req.hdr(host),lower,map(/etc/haproxy/domains-to-backends.map,bk_default)]'
+  }
+}
 ~~~
 
 ##Reference
@@ -410,6 +449,7 @@ The second uses a custom package.
 * [`haproxy::peer`](#define-haproxypeer): Creates server entries within a peers entry in haproxy.cfg.
 * [`haproxy::instance`](#define-instance): Creates multiple instances of haproxy on the same machine.
 * [`haproxy::instance_service`](#define-instanceservice): Example of one way to prepare environment for haproxy::instance.
+* [`haproxy::mapfile`](#define-haproxymapfile): Manages an HAProxy [map file](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#7.3.1-map).
 
 ####Private defines
 
@@ -506,6 +546,8 @@ Main class, includes all other classes.
 * `service_manage`: Specifies whether the state of the HAProxy service should be managed by Puppet. Valid options: 'true' and 'false'. Default: 'true'.
 
 * `service_options`: Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
+
+* `config_dir`: Path to the directory in which the main configuration file `haproxy.cfg` resides. Will also be used for storing any managed map files (see [`haproxy::mapfile`](#define-haproxymapfile). Default depends on platform.
 
 #### Define: `haproxy::balancermember`
 
@@ -754,7 +796,40 @@ Path to the template init.d script that will start/restart/reload this instance.
 * `haproxy_unit_template`:
 Path to the template systemd service unit definition that will start/restart/reload this instance.
 
-##Limitations
+#### Define: `haproxy::mapfile`
+
+Manages an HAProxy [map file](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#7.3.1-map). A map allows to map data in input to other data on output. This is especially useful for efficiently mapping domain names to backends, thus effectively implementing name-based virtual hosting. A map file contains one key + value per line. These key-value pairs are specified in the `mappings` array.
+
+This article on the HAProxy blog gives a nice overview of the use case: http://blog.haproxy.com/2015/01/26/web-application-name-to-backend-mapping-in-haproxy/
+
+##### Parameters
+
+* `namevar`: The namevar of the defined resource type is the filename of the map file (without any extension), relative to the `haproxy::config_dir` directory. A '.map' extension is added automatically.
+
+* `mappings`: An array of mappings for this map file. Array elements may be Hashes with a single key-value pair each (preferably) or simple Strings. Default: `[]`. Example:
+
+  ```puppet
+  mappings => [
+    { 'app01.example.com' => 'bk_app01' },
+    { 'app02.example.com' => 'bk_app02' },
+    { 'app03.example.com' => 'bk_app03' },
+    { 'app04.example.com' => 'bk_app04' },
+    'app05.example.com bk_app05',
+    'app06.example.com bk_app06',
+  ]
+  ```
+
+* `ensure`: The state of the underlying file resource, either 'present' or 'absent'. Default: 'present'
+
+* `owner`: The owner of the underlying file resource. Defaut: 'root'
+
+* `group`: The group of the underlying file resource. Defaut: 'root'
+
+* `mode`:  The mode of the underlying file resource. Defaut: '0644'
+
+* `instances`: Array of names of managed HAproxy instances to notify (restart/reload) when the map file is updated. This is so that the same map file can be used with multiple HAproxy instances (if multiple instances are used). Default: `[ 'haproxy' ]`
+
+## Limitations
 
 This module is tested and officially supported on the following platforms:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,17 +54,22 @@
 #   or add options without having to recreate the entire hash. Defaults to
 #   false, but will default to true in future releases.
 #
-#[*restart_command*]
+# [*restart_command*]
 #   Command to use when restarting the on config changes.
 #    Passed directly as the <code>'restart'</code> parameter to the service resource.
 #    Defaults to undef i.e. whatever the service default is.
 #
-#[*custom_fragment*]
-#  Allows arbitrary HAProxy configuration to be passed through to support
-#  additional configuration not available via parameters, or to short-circute
-#  the defined resources such as haproxy::listen when an operater would rather
-#  just write plain configuration. Accepts a string (ie, output from the
-#  template() function). Defaults to undef
+# [*custom_fragment*]
+#   Allows arbitrary HAProxy configuration to be passed through to support
+#   additional configuration not available via parameters, or to short-circute
+#   the defined resources such as haproxy::listen when an operater would rather
+#   just write plain configuration. Accepts a string (ie, output from the
+#   template() function). Defaults to undef
+#
+# [*config_dir*]
+#   Path to the directory in which the main configuration file `haproxy.cfg`
+#   resides. Will also be used for storing any managed map files (see
+#   `haproxy::mapfile`). Default depends on platform.
 #
 # === Examples
 #
@@ -107,6 +112,7 @@ class haproxy (
   $merge_options    = $haproxy::params::merge_options,
   $restart_command  = undef,
   $custom_fragment  = undef,
+  $config_dir       = $haproxy::params::config_dir,
   $config_file      = $haproxy::params::config_file,
 
   # Deprecated
@@ -124,6 +130,7 @@ class haproxy (
   validate_bool($merge_options)
   validate_string($service_options)
   validate_hash($global_options, $defaults_options)
+  validate_absolute_path($config_dir)
 
   # NOTE: These deprecating parameters are implemented in this class,
   # not in haproxy::instance.  haproxy::instance is new and therefore

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,6 +169,7 @@ class haproxy (
     defaults_options => $defaults_options,
     restart_command  => $restart_command,
     custom_fragment  => $custom_fragment,
+    config_dir       => $config_dir,
     config_file      => $config_file,
     merge_options    => $merge_options,
     service_options  => $service_options,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,13 +14,4 @@ define haproxy::install (
     }
   }
 
-  # Create default configuration directory, gentoo portage does not create it
-  if $::osfamily == 'Gentoo' {
-    file { '/etc/haproxy':
-      ensure  => directory,
-      owner   => 'root',
-      group   => 'root',
-      require => Package[$haproxy::package_name]
-    }
-  }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -143,6 +143,7 @@ define haproxy::instance (
   $defaults_options = undef,
   $restart_command  = undef,
   $custom_fragment  = undef,
+  $config_dir       = undef,
   $config_file      = undef,
   $merge_options    = $haproxy::params::merge_options,
   $service_options  = $haproxy::params::service_options,
@@ -178,15 +179,21 @@ define haproxy::instance (
   #   single-instance hosts: use defaults
   #   multi-instance hosts:  use templates
   if $config_file != undef {
-    $_config_dir = undef
     $_config_file = $config_file
   } else {
     if $instance_name == 'haproxy' {
-      $_config_dir = $haproxy::params::config_dir
       $_config_file = $haproxy::params::config_file
     } else {
-      $_config_dir = inline_template($haproxy::params::config_dir_tmpl)
       $_config_file = inline_template($haproxy::params::config_file_tmpl)
+    }
+  }
+  if $config_dir != undef {
+    $_config_dir = $config_dir
+  } else {
+    if $instance_name == 'haproxy' {
+      $_config_dir = $haproxy::params::config_dir
+    } else {
+      $_config_dir = inline_template($haproxy::params::config_dir_tmpl)
     }
   }
 

--- a/manifests/mapfile.pp
+++ b/manifests/mapfile.pp
@@ -1,0 +1,62 @@
+# == Define Resource Type: haproxy::mapfile
+#
+# Manage an HAProxy map file as documented in
+# https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#7.3.1-map
+# A map file contains one key + value per line. These key-value pairs are
+# specified in the `mappings` array.
+#
+# === Parameters
+#
+# [*name*]
+#   The namevar of the defined resource type is the filename of the map file
+#   (without any extension), relative to the `haproxy::config_dir` directory.
+#   A '.map' extension will be added automatically.
+#
+# [*mappings*]
+#   An array of mappings for this map file. Array elements may be Hashes with a
+#   single key-value pair each (preferably) or simple Strings. Default: `[]`
+#
+# [*ensure*]
+#   The state of the underlying file resource, either 'present' or 'absent'.
+#   Default: 'present'
+#
+# [*owner*]
+#   The owner of the underlying file resource. Defaut: 'root'
+#
+# [*group*]
+#   The group of the underlying file resource. Defaut: 'root'
+#
+# [*mode*]
+#   The mode of the underlying file resource. Defaut: '0644'
+#
+# [*instances*]
+#   Array of managed HAproxy instance names to notify (restart/reload) when the
+#   map file is updated. This is so that the same map file can be used with
+#   multiple HAproxy instances. Default: `[ 'haproxy' ]`
+#
+define haproxy::mapfile (
+  $mappings  = [],
+  $ensure    = 'present',
+  $owner     = 'root',
+  $group     = 'root',
+  $mode      = '0644',
+  $instances = [ 'haproxy' ],
+) {
+  $mapfile_name = $title
+
+  validate_re($ensure, '^present|absent$', "Haproxy::Mapfile[${mapfile_name}]: '${ensure}' is not supported for ensure. Allowed values are 'present' and 'absent'.")
+  validate_array($mappings)
+  validate_array($instances)
+
+  $_instances = flatten($instances)
+
+  file { "haproxy_mapfile_${mapfile_name}":
+    ensure  => $ensure,
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
+    content => template('haproxy/haproxy_mapfile.erb'),
+    path    => "${haproxy::config_dir}/${mapfile_name}.map",
+    notify  => Haproxy::Service[$_instances],
+  }
+}

--- a/spec/defines/mapfile_spec.rb
+++ b/spec/defines/mapfile_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'haproxy::mapfile' do
+  let(:pre_condition) { 'include haproxy' }
+  let(:title) { 'domains-to-backends' }
+  let(:facts) do
+    {
+      :ipaddress      => '1.1.1.1',
+      :osfamily       => 'Redhat',
+      :concat_basedir => '/dne',
+    }
+  end
+  context "map domains to backends" do
+    let(:params) do
+      {
+        :ensure => 'present',
+        :mappings => [
+          { 'app01.example.com' => 'bk_app01' },
+          { 'app02.example.com' => 'bk_app02' },
+          { 'app03.example.com' => 'bk_app03' },
+          { 'app04.example.com' => 'bk_app04' },
+          'app05.example.com bk_app05',
+          'app06.example.com bk_app06',
+        ],
+        :instances => [ 'haproxy' ],
+      }
+    end
+
+    it { should contain_file('haproxy_mapfile_domains-to-backends').that_notifies('Haproxy::Service[haproxy]') }
+    it { should contain_file('haproxy_mapfile_domains-to-backends').with(
+      'path'    => '/etc/haproxy/domains-to-backends.map',
+      'ensure'  => 'present',
+      'content' => "# HAProxy map file \"domains-to-backends\"\n# Managed by Puppet\n\napp01.example.com bk_app01\napp02.example.com bk_app02\napp03.example.com bk_app03\napp04.example.com bk_app04\napp05.example.com bk_app05\napp06.example.com bk_app06\n" ) }
+  end
+
+  context "fail if a non-array is supplied for mappings" do
+    let(:params) do
+      {
+        :ensure => 'present',
+        :mappings => { 'foo' => 'bar' },
+      }
+    end
+
+    it 'should raise error' do
+      expect { catalogue }.to raise_error Puppet::Error, /is not an Array/
+    end
+  end
+end

--- a/templates/haproxy_mapfile.erb
+++ b/templates/haproxy_mapfile.erb
@@ -1,0 +1,18 @@
+# HAProxy map file "<%= @mapfile_name -%>"
+# Managed by Puppet
+
+<%# Iterate over array elements; If element is a Hash sort it by its keys, -%>
+<%# just in case, then output each key-value pair. If element is a String -%>
+<%# then simply output the String value. Fail if the array contains anything -%>
+<%# other than Hashes or Strings. -%>
+<%- @mappings.each do |mapping| -%>
+<%- if mapping.is_a?(Hash) -%>
+<%- mapping.sort.map do |key, val| -%>
+<%= key -%> <%= val %>
+<%- end -%>
+<%- elsif mapping.is_a?(String) -%>
+<%= mapping %>
+<%- else -%>
+<% scope.function_fail(["Haproxy::Mapfile[#{@mapfile_name}]: $mappings array must contain only Hashes or Strings"]) -%>
+<%- end -%>
+<%- end -%>


### PR DESCRIPTION
Add a defined type haproxy::mapfile to manage map files as documented in
https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#7.3.1-map

A map file contains one key + value pair per line. These mappings are
modelled in a `mappings` array, whose elements may either be Hashes with
a single key-value pair each or simple Strings.

Contains updated documentation and spec tests for the new defined type.