### PR TITLE
Match only on strings because ruby1.8--

### DIFF
--- a/templates/fragments/_bind.erb
+++ b/templates/fragments/_bind.erb
@@ -12,7 +12,7 @@
   rescue ArgumentError => e
     valid_ip = false
   end
-  if ! valid_ip and ! virtual_ip.match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and virtual_ip != "*"
+  if ! valid_ip and ! String(virtual_ip).match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and virtual_ip != "*"
     scope.function_fail(["Invalid IP address or hostname [#{virtual_ip}]"])
   end
   scope.function_fail(["Port [#{port}] is outside of range 1-65535"]) if port.to_i < 1 or port.to_i > 65535


### PR DESCRIPTION
Ruby 1.8 doesn't have `.match` for symbols; 1.8 EOL but is still the
packaged version that ships with EL6 so some users are still hitting
this bug.