### PR TITLE
Only create config_dir in specific cases.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,7 @@ define haproxy::config (
   $custom_fragment = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   $merge_options = $haproxy::merge_options,
 ) {
+
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
@@ -21,12 +22,14 @@ define haproxy::config (
     warning("${module_name}: The \$merge_options parameter will default to true in the next major release. Please review the documentation regarding the implications.")
   }
 
-  if $config_dir != undef {
-    file { $config_dir:
-      ensure => directory,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0755',
+  if $haproxy::params::manage_config_dir {
+    if $config_dir != undef {
+      file { $config_dir:
+        ensure => directory,
+        owner  => '0',
+        group  => '0',
+        mode   => '0755',
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,18 +102,19 @@
 #  }
 #
 class haproxy (
-  $package_ensure   = 'present',
-  $package_name     = $haproxy::params::package_name,
-  $service_ensure   = 'running',
-  $service_manage   = true,
-  $service_options  = $haproxy::params::service_options,
-  $global_options   = $haproxy::params::global_options,
-  $defaults_options = $haproxy::params::defaults_options,
-  $merge_options    = $haproxy::params::merge_options,
-  $restart_command  = undef,
-  $custom_fragment  = undef,
-  $config_dir       = $haproxy::params::config_dir,
-  $config_file      = $haproxy::params::config_file,
+  $package_ensure    = 'present',
+  $package_name      = $haproxy::params::package_name,
+  $service_ensure    = 'running',
+  $service_manage    = true,
+  $service_options   = $haproxy::params::service_options,
+  $global_options    = $haproxy::params::global_options,
+  $defaults_options  = $haproxy::params::defaults_options,
+  $merge_options     = $haproxy::params::merge_options,
+  $restart_command   = undef,
+  $custom_fragment   = undef,
+  $config_dir        = $haproxy::params::config_dir,
+  $config_file       = $haproxy::params::config_file,
+  $manage_config_dir = $haproxy::params::manage_config_dir,
 
   # Deprecated
   $manage_service   = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,8 +12,8 @@ class haproxy::params {
 
   case $::osfamily {
     'Archlinux', 'Debian', 'Redhat', 'Gentoo', 'Suse' : {
-      $package_name     = 'haproxy'
-      $global_options   = {
+      $package_name      = 'haproxy'
+      $global_options    = {
         'log'     => "${::ipaddress} local0",
         'chroot'  => '/var/lib/haproxy',
         'pidfile' => '/var/run/haproxy.pid',
@@ -23,7 +23,7 @@ class haproxy::params {
         'daemon'  => '',
         'stats'   => 'socket /var/lib/haproxy/stats'
       }
-      $defaults_options = {
+      $defaults_options  = {
         'log'     => 'global',
         'stats'   => 'enable',
         'option'  => [ 'redispatch' ],
@@ -39,15 +39,16 @@ class haproxy::params {
         'maxconn' => '8000'
       }
       # Single instance:
-      $config_dir       = '/etc/haproxy'
-      $config_file      = '/etc/haproxy/haproxy.cfg'
+      $config_dir        = '/etc/haproxy'
+      $config_file       = '/etc/haproxy/haproxy.cfg'
+      $manage_config_dir = true
       # Multi-instance:
-      $config_dir_tmpl  = '/etc/<%= @instance_name %>'
-      $config_file_tmpl = "${config_dir_tmpl}/<%= @instance_name %>.cfg"
+      $config_dir_tmpl   = '/etc/<%= @instance_name %>'
+      $config_file_tmpl  = "${config_dir_tmpl}/<%= @instance_name %>.cfg"
     }
     'FreeBSD': {
-      $package_name     = 'haproxy'
-      $global_options   = {
+      $package_name      = 'haproxy'
+      $global_options    = {
         'log'     => [
           '127.0.0.1 local0',
           '127.0.0.1 local1 notice',
@@ -57,7 +58,7 @@ class haproxy::params {
         'maxconn' => '4096',
         'daemon'  => '',
       }
-      $defaults_options = {
+      $defaults_options  = {
         'log'        => 'global',
         'mode'       => 'http',
         'option'     => [
@@ -72,8 +73,9 @@ class haproxy::params {
         'srvtimeout' => '50000',
       }
       # Single instance:
-      $config_dir       = '/usr/local/etc'
-      $config_file      = '/usr/local/etc/haproxy.conf'
+      $config_dir        = '/usr/local/etc'
+      $config_file       = '/usr/local/etc/haproxy.conf'
+      $manage_config_dir = false
       # Multi-instance:
       $config_dir_tmpl  = '/usr/local/etc/<%= @instance_name %>'
       $config_file_tmpl = "${config_dir_tmpl}/<%= @instance_name %>.conf"


### PR DESCRIPTION
8adbf88bc353c3882e9c3a5a3b92e20ffa830f26 began managing the $config_dir, but that is only necessary if the default value isn't used or if the default is used AND the OS is gentoo.  we ran into a an issue where the $config_dir is being managed by another module, and we therefore had duplicate resources.  this change addresses that since in all other cases the $config_dir either exists by default (e.g., FreeBSD) or is created when the haproxy package is installed (seemingly every OS except Gentoo).

//cc @jewjitsu