### PR TITLE
MODULES-2951 Added support for individual weights for balancermembers.

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -39,6 +39,10 @@
 #   The ip address used to contact the balancer member server.
 #    Can be an array, see documentation to server_names.
 #
+# [*weights*]
+#   The weight(s) used for balancer member.
+#    Can be an array, see documentation to weights.
+#
 # [*ensure*]
 #   If the balancermember should be present or absent.
 #    Defaults to present.
@@ -87,6 +91,7 @@ define haproxy::balancermember (
   $ports        = undef,
   $server_names = $::hostname,
   $ipaddresses  = $::ipaddress,
+  $weight       = undef,
   $ensure       = 'present',
   $options      = '',
   $define_cookies = false,

--- a/templates/haproxy_balancermember.erb
+++ b/templates/haproxy_balancermember.erb
@@ -1,3 +1,17 @@
+<% if @weights -%>
+
+<% Array(@ipaddresses).zip(Array(@server_names), Array(@weights)).each do |ipaddress,host,weight| -%>
+<% if @ports -%>
+<%- Array(@ports).each do |port| -%>
+  server <%= host %> <%= ipaddress %>:<%= port %> weight <%= weight %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %>
+<%- end -%>
+<% else -%>
+  server <%= host %> <%= ipaddress %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %>
+<%- end -%>
+<% end -%>
+
+<% else -%>
+
 <% Array(@ipaddresses).zip(Array(@server_names)).each do |ipaddress,host| -%>
 <% if @ports -%>
 <%- Array(@ports).each do |port| -%>
@@ -6,4 +20,6 @@
 <% else -%>
   server <%= host %> <%= ipaddress %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %>
 <%- end -%>
+<% end -%>
+
 <% end -%>


### PR DESCRIPTION
Changes done to manifests/balancermember.pp and templates/haproxy_balancermember.erb

In manifests/balancermember.pp I have added in the definition of data type a line for a weights array that is undefined by default.

In templates/haproxy_balancermember.erb I have added a check to see if weights contain data, and if so print the correct line with weights added to it, otherwise do the original code.