### PR TITLE
Added support for individual weights for balancermembers. (MODULES-2951)

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -33,11 +33,16 @@
 #    listening service's configuration block. This defaults to the
 #    hostname. Can be an array of the same length as ipaddresses,
 #    in which case a balancermember is created for each pair of
-#    server_names and ipaddresses (in lockstep).
+#    server_names and ipaddresses (in lockstep). Also, weights if provided, 
+#    will also be part of the lockstep.
 #
 # [*ipaddresses*]
 #   The ip address used to contact the balancer member server.
 #    Can be an array, see documentation to server_names.
+#
+# [*weights*]
+#   The weight(s) used for balancer member.
+#    Can be an array, see documentation to weights.
 #
 # [*ensure*]
 #   If the balancermember should be present or absent.
@@ -87,6 +92,7 @@ define haproxy::balancermember (
   $ports        = undef,
   $server_names = $::hostname,
   $ipaddresses  = $::ipaddress,
+  $weights      = undef,
   $ensure       = 'present',
   $options      = '',
   $define_cookies = false,

--- a/templates/haproxy_balancermember.erb
+++ b/templates/haproxy_balancermember.erb
@@ -1,9 +1,10 @@
-<% Array(@ipaddresses).zip(Array(@server_names)).each do |ipaddress,host| -%>
+<% Array(@ipaddresses).zip(Array(@server_names), Array(@weights)).each do |ipaddress,host,weight| -%>
+<% weight_option = " weight #{weight}" if weight -%>
 <% if @ports -%>
 <%- Array(@ports).each do |port| -%>
-  server <%= host %> <%= ipaddress %>:<%= port %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %>
+  server <%= host %> <%= ipaddress %>:<%= port %><%= weight_option %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %>
 <%- end -%>
 <% else -%>
-  server <%= host %> <%= ipaddress %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %>
+  server <%= host %> <%= ipaddress %><%= weight_option %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %>
 <%- end -%>
 <% end -%>


### PR DESCRIPTION
Changes done to manifests/balancermember.pp and templates/haproxy_balancermember.erb

In manifests/balancermember.pp I have added in the definition of data type a line for a weights array that is undefined by default.

In templates/haproxy_balancermember.erb I have added a check to see if weights contain data, and if so print the correct line with weights added to it, otherwise do the original code.