### PR TITLE
MODULES-2938/restore target feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,8 @@ Configures a service inside a listening or backend service configuration block i
 
 * `defaults`: *Optional.* Name of the defaults section the backend or listener use. Defaults to undef.
 
+* `config_file`: *Optional.* Path of the config file where this entry will be added. Assumes that the parent directory exists. Defaults to `haproxy::params::config_file`.
+
 #### Define: `haproxy::backend`
 
 Sets up a backend service configuration block inside haproxy.cfg. Each backend service needs one or more balancermember services (declared with the [`haproxy::balancermember` define](#define-haproxybalancermember)).
@@ -608,8 +610,11 @@ Sets up a backend service configuration block inside haproxy.cfg. Each backend s
 
 * `options`: *Optional.* Adds one or more options to the backend service's configuration block in haproxy.cfg. Valid options: a hash or an array. To control the ordering of these options within the configuration block, supply an array of hashes where each hash contains one 'option => value' pair. Default:
 
+* `config_file`: *Optional.* Path of the config file where this entry will be added. Assumes that the parent directory exists. Defaults to `haproxy::params::config_file`.
+
   ```puppet
   {
+
     'option'  => [
       'tcplog',
       'ssl-hello-chk'
@@ -672,6 +677,8 @@ For more information, see the [HAProxy Configuration Manual](http://cbonte.githu
 
 * `defaults_use_backend`: If defaults are used and a default backend is configured use the backend name for ordering. This means that the frontend is placed in the configuration file before the backend configuration. Defaults to true.
 
+* `config_file`: *Optional.* Path of the config file where this entry will be added. Assumes that the parent directory exists. Defaults to `haproxy::params::config_file`.
+
 #### Define: `haproxy::listen`
 
 Sets up a listening service configuration block inside haproxy.cfg. Each listening service configuration needs one or more balancermember services (declared with the [`haproxy::balancermember` define](#define-haproxybalancermember)).
@@ -710,6 +717,8 @@ For more information, see the [HAProxy Configuration Manual](http://cbonte.githu
 
 * `defaults`: *Optional* Name of the defaults section this listen section will use. Defaults to undef which means the global defaults section will be used.
 
+* `config_file`: *Optional.* Path of the config file where this entry will be added. Assumes that the parent directory exists. Defaults to `haproxy::params::config_file`.
+
 #### Define: `haproxy::userlist`
 
 Sets up a [userlist configuration block](http://cbonte.github.io/haproxy-dconv/configuration-1.4.html#3.4) inside haproxy.cfg.
@@ -724,6 +733,8 @@ Sets up a [userlist configuration block](http://cbonte.github.io/haproxy-dconv/c
 
 * `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
 
+* `config_file`: *Optional.* Path of the config file where this entry will be added. Assumes that the parent directory exists. Defaults to `haproxy::params::config_file`.
+
 #### Define: `haproxy::peers`
 
 Sets up a peers entry in haproxy.cfg on the load balancer. This entry is required to share the current state of HAProxy with other HAProxy instances in high-availability configurations.
@@ -735,6 +746,8 @@ Sets up a peers entry in haproxy.cfg on the load balancer. This entry is require
 * `name`: *Optional.* Appends a name to the peers entry in haproxy.cfg. Valid options: a string. Default: the title of your declared resource.
 
 * `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
+
+* `config_file`: *Optional.* Path of the config file where this entry will be added. Assumes that the parent directory exists. Defaults to `haproxy::params::config_file`.
 
 #### Define: `haproxy::peer`
 
@@ -778,6 +791,8 @@ Sets up a mailer entry inside the mailers configuration block in haproxy.cfg.
 * `server_names`: *Required unless the `collect_exported` parameter of your `haproxy::mailers` resource is set to `true`.* Sets the name of the email server as listed in the mailers configuration block. Valid options: a string or an array. If you pass an array, it must contain the same number of elements as the array you pass to `ipaddresses`. Puppet pairs up the elements from both arrays and creates a mailer for each pair of values. Default: the value of the `$::hostname` fact.
 
 * `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
+
+* `config_file`: *Optional.* Path of the config file where this entry will be added. Assumes that the parent directory exists. Defaults to `haproxy::params::config_file`.
 
 #### Define: `haproxy::instance`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,10 @@
 #   resides. Will also be used for storing any managed map files (see
 #   `haproxy::mapfile`). Default depends on platform.
 #
+# [*config_file*]
+#   Optional. Path to the haproxy config file.
+#   Default depends on platform.
+#
 # === Examples
 #
 #  class { 'haproxy':

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -179,23 +179,18 @@ define haproxy::instance (
   #   If config_dir defined, use it.  Otherwise:
   #   single-instance hosts: use defaults
   #   multi-instance hosts:  use templates
-  if $config_file != undef {
-    $_config_file = $config_file
+  if $instance_name == 'haproxy' {
+    $_config_file = pick($config_file, $haproxy::params::config_file)
   } else {
-    if $instance_name == 'haproxy' {
-      $_config_file = $haproxy::params::config_file
-    } else {
-      $_config_file = inline_template($haproxy::params::config_file_tmpl)
-    }
+    $_config_file = pick($config_file, inline_template($haproxy::params::config_file_tmpl))
   }
-  if $config_dir != undef {
-    $_config_dir = $config_dir
+
+  validate_absolute_path(dirname($_config_file))
+
+  if $instance_name == 'haproxy' {
+    $_config_dir = pick($config_dir, $haproxy::params::config_dir)
   } else {
-    if $instance_name == 'haproxy' {
-      $_config_dir = $haproxy::params::config_dir
-    } else {
-      $_config_dir = inline_template($haproxy::params::config_dir_tmpl)
-    }
+    $_config_dir = pick($config_dir, inline_template($haproxy::params::config_dir_tmpl))
   }
 
   haproxy::config { $title:

--- a/manifests/mailer.pp
+++ b/manifests/mailer.pp
@@ -28,6 +28,11 @@
 #
 # [*ports*]
 #  Sets the port on which the mailer is going to share the state.
+#
+# [*config_file*]
+#   Optional. Path of the config file where this entry will be added.
+#   Assumes that the parent directory exists.
+#   Default: $haproxy::params::config_file
 
 define haproxy::mailer (
   $mailers_name,

--- a/manifests/mailers.pp
+++ b/manifests/mailers.pp
@@ -9,6 +9,11 @@
 #  Sets the mailers' name. Generally it will be the namevar of the
 #   defined resource type. This value appears right after the
 #   'mailers' statement in haproxy.cfg
+#
+# [*config_file*]
+#   Optional. Path of the config file where this entry will be added.
+#   Assumes that the parent directory exists.
+#   Default: $haproxy::params::config_file
 
 define haproxy::mailers (
   $collect_exported = true,


### PR DESCRIPTION
Restore the behavior of the old undocumented `target` parameter.

Change config files to support a `config_file` parameter, which offers the same behavior as the old `target` parameter. `target` was previously available (in at least version 1.0.0), but undocumented, as a way to change the destination for config text.

See https://tickets.puppetlabs.com/browse/MODULES-2938 for reference.