### PR TITLE
Fix markup around section "Manage a map file"

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ The second uses a custom package.
      ipaddress        => $::ipaddress,
      ports            => '9900',
    }
+~~~
 
 ### Manage a map file
 


### PR DESCRIPTION
A closing `~~~` was missing in the previous section.