### PR TITLE
No longer add $ensure to balancermember concat fragments

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -39,10 +39,6 @@
 #   The ip address used to contact the balancer member server.
 #    Can be an array, see documentation to server_names.
 #
-# [*ensure*]
-#   If the balancermember should be present or absent.
-#    Defaults to present.
-#
 # [*options*]
 #   An array of options to be specified after the server declaration
 #    in the listening service's configuration block.
@@ -87,7 +83,6 @@ define haproxy::balancermember (
   $ports        = undef,
   $server_names = $::hostname,
   $ipaddresses  = $::ipaddress,
-  $ensure       = 'present',
   $options      = '',
   $define_cookies = false,
   $instance     = 'haproxy',
@@ -104,7 +99,6 @@ define haproxy::balancermember (
 
   # Template uses $ipaddresses, $server_name, $ports, $option
   concat::fragment { "${instance_name}-${listening_service}_balancermember_${name}":
-    ensure  => $ensure,
     order   => "20-${listening_service}-01-${name}",
     target  => $config_file,
     content => template('haproxy/haproxy_balancermember.erb'),

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -29,24 +29,6 @@ describe 'haproxy::balancermember' do
     ) }
   end
 
-  context 'with a balancermember with ensure => absent ' do
-    let(:params) do
-      {
-        :name              => 'tyler',
-        :listening_service => 'croy',
-        :ports             => '18140',
-        :ensure            => 'absent'
-      }
-    end
-
-    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
-      'order'   => '20-croy-01-tyler',
-      'target'  => '/etc/haproxy/haproxy.cfg',
-      'ensure'  => 'absent',
-      'content' => "  server dero 1.1.1.1:18140 \n"
-    ) }
-  end
-
   context 'with multiple balancermember options' do
     let(:params) do
       {


### PR DESCRIPTION
Concat has deprecated the ensure parameter, and this is producing warnings in the server logs.

```shell
2016-02-23 13:42:17,741 WARN  [puppet-server] Scope(Concat::Fragment[haproxy-blah_balancermember_blah_1]) The $ensure parameter to concat::fragment is deprecated and has no effect.  
2016-02-23 13:42:52,278 WARN  [puppet-server] Scope(Haproxy::Config[haproxy]) haproxy: The $merge_options parameter will default to true in the next major release. Please review the documentation regarding the implications.
```