### PR TITLE
bugfix: correct class for sort_options_alphabetic acceptance test

### DIFF
--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -61,7 +61,7 @@ describe "configuring haproxy", :unless => UNSUPPORTED_PLATFORMS.include?(fact('
     describe "with sort_options_alphabetic false" do
       it 'should start' do
         pp = <<-EOS
-        class { 'haproxy::params':
+        class { 'haproxy::globals':
           sort_options_alphabetic => false,
         }
         class { 'haproxy': }


### PR DESCRIPTION
sorry, my bad. I missed this file during the switch from `haproxy::params::sort_options_alphabetic` to `haproxy::globals::sort_options_alphabetic`.