### PR TITLE
add option to use multiple defaults sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ haproxy::frontend { 'ft_allapps':
 * [`haproxy::instance`](#define-instance): Creates multiple instances of haproxy on the same machine.
 * [`haproxy::instance_service`](#define-instanceservice): Example of one way to prepare environment for haproxy::instance.
 * [`haproxy::mapfile`](#define-haproxymapfile): Manages an HAProxy [map file](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#7.3.1-map).
+* [`haproxy::defaults`](#define-defaults): Option to use multipe defaults sections.
 
 ####Private defines
 
@@ -591,6 +592,8 @@ Configures a service inside a listening or backend service configuration block i
 
 * `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
 
+* `defaults`: *Optional.* Name of the defaults section the backend or listener use. Defaults to undef.
+
 #### Define: `haproxy::backend`
 
 Sets up a backend service configuration block inside haproxy.cfg. Each backend service needs one or more balancermember services (declared with the [`haproxy::balancermember` define](#define-haproxybalancermember)).
@@ -616,6 +619,8 @@ Sets up a backend service configuration block inside haproxy.cfg. Each backend s
 * `instance`: *Optional.* When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
 
 * `sort_options_alphabetic`: Sort options either alphabetic or custom like haproxy internal sorts them. Defaults to `haproxy::globals::sort_options_alphabetic`.
+
+* `defaults`: *Optional* Name of the defaults section this backend will use. Defaults to undef which means the global defaults section will be used.
 
 #### Define: `haproxy::frontend`
 
@@ -661,6 +666,10 @@ For more information, see the [HAProxy Configuration Manual](http://cbonte.githu
 
 * `sort_options_alphabetic`: Sort options either alphabetic or custom like haproxy internal sorts them. Defaults to `haproxy::globals::sort_options_alphabetic`.
 
+* `defaults`: *Optional* Name of the defaults section this frontend will use. Defaults to undef which means the global defaults section will be used.
+
+* `defaults_use_backend`: If defaults are used and a default backend is configured use the backend name for ordering. This means that the frontend is placed in the configuration file before the backend configuration. Defaults to true.
+
 #### Define: `haproxy::listen`
 
 Sets up a listening service configuration block inside haproxy.cfg. Each listening service configuration needs one or more balancermember services (declared with the [`haproxy::balancermember` define](#define-haproxybalancermember)).
@@ -696,6 +705,8 @@ For more information, see the [HAProxy Configuration Manual](http://cbonte.githu
 * `ports`: *Required unless `bind` is specified.* Specifies which ports to listen on for the address specified in `ipaddress`. Valid options: a single comma-delimited string or an array of strings. Each string can contain a port number or a hyphenated range of port numbers (e.g., 8443-8450).
 
 * `sort_options_alphabetic`: Sort options either alphabetic or custom like haproxy internal sorts them. Defaults to `haproxy::globals::sort_options_alphabetic`.
+
+* `defaults`: *Optional* Name of the defaults section this listen section will use. Defaults to undef which means the global defaults section will be used.
 
 #### Define: `haproxy::userlist`
 
@@ -878,6 +889,18 @@ This article on the HAProxy blog gives a nice overview of the use case: http://b
 * `mode`:  The mode of the underlying file resource. Defaut: '0644'
 
 * `instances`: Array of names of managed HAproxy instances to notify (restart/reload) when the map file is updated. This is so that the same map file can be used with multiple HAproxy instances (if multiple instances are used). Default: `[ 'haproxy' ]`
+
+#### Define: `haproxy::defaults`
+
+This type will setup a additional defaults configuration block inside the haproxy.cfg file on an haproxy load balancer. A new default configuration block resets all defaults of prior defaults configuration blocks. [Further documentation](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4) of what options are allowed in defaults sections. Listener, Backends, Frontends and Balancermember can be configured behind a default configuration block by setting the defaults parameter to the corresponding defaults name.
+
+##### Parameters (all optional)
+
+* `options`: A hash or array of hashes of options that are inserted into the defaults configuration block.
+
+* `sort_options_alphabetic`: Sort options either alphabetic or custom like haproxy internal sorts them. Defaults to true.
+
+* `instance`: When using `haproxy::instance` to run multiple instances of Haproxy on the same machine, this indicates which instance.  Defaults to "haproxy".
 
 ## Limitations
 

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -38,6 +38,10 @@
 #   Sort options either alphabetic or custom like haproxy internal sorts them.
 #   Defaults to true.
 #
+# [*defaults*]
+#   Name of the defaults section this backend will use.
+#   Defaults to undef which means the global defaults section will be used.
+#
 # === Examples
 #
 #  Exporting the resource for a backend member:
@@ -69,6 +73,7 @@ define haproxy::backend (
   $instance                = 'haproxy',
   $section_name            = $name,
   $sort_options_alphabetic = undef,
+  $defaults                = undef,
 ) {
   if defined(Haproxy::Listen[$section_name]) {
     fail("An haproxy::listen resource was discovered with the same name (${section_name}) which is not supported")
@@ -85,9 +90,15 @@ define haproxy::backend (
   include ::haproxy::globals
   $_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
 
+  if $defaults == undef {
+    $order = "20-${section_name}-00"
+  } else {
+    $order = "25-${defaults}-${section_name}-01"
+  }
+
   # Template uses: $section_name, $ipaddress, $ports, $options
   concat::fragment { "${instance_name}-${section_name}_backend_block":
-    order   => "20-${section_name}-00",
+    order   => $order,
     target  => $config_file,
     content => template('haproxy/haproxy_backend_block.erb'),
   }

--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -47,6 +47,10 @@
 #   If true, then add "cookie SERVERID" stickiness options.
 #    Default false.
 #
+# [*defaults*]
+#   Name of the defaults section the backend or listener use.
+#   Defaults to undef.
+#
 # === Examples
 #
 #  Exporting the resource for a balancer member:
@@ -86,6 +90,7 @@ define haproxy::balancermember (
   $options      = '',
   $define_cookies = false,
   $instance     = 'haproxy',
+  $defaults     = undef,
 ) {
 
   include haproxy::params
@@ -97,9 +102,14 @@ define haproxy::balancermember (
     $config_file = inline_template($haproxy::params::config_file_tmpl)
   }
 
+  if $defaults == undef {
+    $order = "20-${listening_service}-01-${name}"
+  } else {
+    $order = "25-${defaults}-${listening_service}-02-${name}"
+  }
   # Template uses $ipaddresses, $server_name, $ports, $option
   concat::fragment { "${instance_name}-${listening_service}_balancermember_${name}":
-    order   => "20-${listening_service}-01-${name}",
+    order   => $order,
     target  => $config_file,
     content => template('haproxy/haproxy_balancermember.erb'),
   }

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -1,0 +1,42 @@
+# == Define Resource Type: haproxy::defaults
+#
+# This type will setup a additional defaults configuration block inside the
+#  haproxy.cfg file on an haproxy load balancer. A new default configuration
+#  block resets all defaults of prior defaults configuration blocks. Listener,
+#  Backends, Frontends and Balancermember can be configured behind a default
+#  configuration block by setting the defaults parameter to the corresponding
+#  defaults name.
+#
+# === Parameters:
+#
+# [*options*]
+#   A hash of options that are inserted into the defaults configuration block.
+#
+# [*sort_options_alphabetic*]
+#   Sort options either alphabetic or custom like haproxy internal sorts them.
+#   Defaults to true.
+
+define haproxy::defaults (
+  $options                 = {},
+  $sort_options_alphabetic = undef,
+  $instance                = 'haproxy',
+) {
+
+  if $instance == 'haproxy' {
+    include haproxy
+    $instance_name = 'haproxy'
+    $config_file = $haproxy::config_file
+  } else {
+    include haproxy::params
+    $instance_name = "haproxy-${instance}"
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+  include haproxy::globals
+  $_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
+
+  concat::fragment { "${instance_name}-${name}_defaults_block":
+    order   => "25-${name}",
+    target  => $config_file,
+    content => template('haproxy/haproxy_defaults_block.erb'),
+  }
+}

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -58,6 +58,10 @@
 #   Sort options either alphabetic or custom like haproxy internal sorts them.
 #   Defaults to true.
 #
+# [*defaults*]
+#   Name of the defaults section this backend will use.
+#   Defaults to undef which means the global defaults section will be used.
+#
 # === Examples
 #
 #  Exporting the resource for a balancer member:
@@ -94,6 +98,7 @@ define haproxy::listen (
   $instance                     = 'haproxy',
   $section_name                 = $name,
   $sort_options_alphabetic      = undef,
+  $defaults                     = undef,
   # Deprecated
   $bind_options                 = '',
 ) {
@@ -125,9 +130,15 @@ define haproxy::listen (
   include haproxy::globals
   $_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
 
+  if $defaults == undef {
+    $order = "20-${section_name}-00"
+  } else {
+    $order = "25-${defaults}-${section_name}-00"
+  }
+
   # Template uses: $section_name, $ipaddress, $ports, $options
   concat::fragment { "${instance_name}-${section_name}_listen_block":
-    order   => "20-${section_name}-00",
+    order   => $order,
     target  => $config_file,
     content => template('haproxy/haproxy_listen_block.erb'),
   }

--- a/spec/acceptance/defaults_spec.rb
+++ b/spec/acceptance/defaults_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper_acceptance'
+
+describe "frontend backend defines with defaults", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  it 'should be able to configure defaults with puppet' do
+    pp = <<-EOS
+      class { 'haproxy::globals':
+        sort_options_alphabetic => false,
+      }
+      class { 'haproxy': }
+      haproxy::defaults { 'http':
+        options => {
+          option => [
+            'redispatch',
+          ],
+          'stats'   => 'enable',
+          'log'     => 'global',
+          retries => 3,
+          'timeout client' => '3s',
+          'timeout server' => '3s',
+          'timeout connect' => '1s',
+          'timeout queue' => '10s',
+          'timeout check' => '1s',
+          'timeout http-request' => '2s',
+          balance => 'roundrobin',
+          'maxconn' => '8000',
+          'default-server' => 'weight 100 inter 6s fastinter 1s downinter 3s fall 2 rise 4',
+
+        }
+      }
+      haproxy::frontend { 'app00':
+        ipaddress => $::ipaddress_lo,
+        mode      => 'http',
+        ports     => '5555',
+        defaults  => 'http',
+        options   => { 'default_backend' => 'app00' },
+      }
+      haproxy::backend { 'app00':
+        defaults         => 'http',
+        collect_exported => false,
+        options          => { 'mode' => 'http' },
+      }
+      haproxy::balancermember { 'port 5556':
+        listening_service => 'app00',
+        defaults          => 'http',
+        ports             => '5556',
+      }
+     haproxy::balancermember { 'port 5557':
+        listening_service => 'app00',
+        defaults          => 'http',
+        ports             => '5557',
+      }
+    EOS
+    apply_manifest(pp, :catch_failures => true)
+  end
+
+  it "should do a curl against the LB to make sure it gets a response from each port" do
+    #shell('cat /etc/haproxy/haproxy.cfg').stdout.should match(/^$/)
+    shell('curl localhost:5555').stdout.chomp.should match(/Response on 555(6|7)/)
+    shell('curl localhost:5555').stdout.chomp.should match(/Response on 555(6|7)/)
+  end
+
+  it 'should be able to configure defaults and old style with puppet' do
+    pp = <<-EOS
+      class { 'haproxy::globals':
+        sort_options_alphabetic => false,
+      }
+      class { 'haproxy': }
+      haproxy::defaults { 'http':
+        options => {
+          option => [
+            'redispatch',
+          ],
+          'stats'   => 'enable',
+          'log'     => 'global',
+          retries => 3,
+          'timeout client' => '3s',
+          'timeout server' => '3s',
+          'timeout connect' => '1s',
+          'timeout queue' => '10s',
+          'timeout check' => '1s',
+          'timeout http-request' => '2s',
+          balance => 'roundrobin',
+          'maxconn' => '8000',
+          'default-server' => 'weight 100 inter 6s fastinter 1s downinter 3s fall 2 rise 4',
+
+        }
+      }
+      haproxy::frontend { 'app00':
+        ipaddress => $::ipaddress_lo,
+        mode      => 'http',
+        ports     => '5555',
+        defaults  => 'http',
+        options   => { 'default_backend' => 'app00' },
+      }
+      haproxy::backend { 'app00':
+        defaults         => 'http',
+        collect_exported => false,
+        options          => { 'mode' => 'http' },
+      }
+      haproxy::balancermember { 'port 5556':
+        listening_service => 'app00',
+        defaults          => 'http',
+        ports             => '5556',
+      }
+      haproxy::frontend { 'app01':
+        ipaddress => $::ipaddress_lo,
+        mode      => 'http',
+        ports     => '6666',
+        options   => { 'default_backend' => 'app01' },
+      }
+      haproxy::backend { 'app01':
+        collect_exported => false,
+        options          => { 'mode' => 'http' },
+      }
+      haproxy::balancermember { 'port 5557':
+        listening_service => 'app01',
+        ports             => '5557',
+      }
+    EOS
+    apply_manifest(pp, :catch_failures => true)
+  end
+
+  it "should do a curl against the LB to make sure it gets a response from each port" do
+    #shell('cat /etc/haproxy/haproxy.cfg').stdout.should match(/^$/)
+    shell('curl localhost:5555').stdout.chomp.should match(/Response on 5556/)
+    shell('curl localhost:6666').stdout.chomp.should match(/Response on 5557/)
+  end
+end

--- a/spec/defines/defaults_spec.rb
+++ b/spec/defines/defaults_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'haproxy::defaults' do
+  let :pre_condition do
+    'class{"haproxy":
+        config_file => "/tmp/haproxy.cfg"
+     }
+    '
+  end
+  let(:title) { 'test' }
+  let(:facts) do
+    {
+      :ipaddress      => '1.1.1.1',
+      :osfamily       => 'RedHat',
+      :concat_basedir => '/dne',
+    }
+  end
+
+  context 'with a single option' do
+    let(:params) do
+      {
+        :options => { 'balance' => 'roundrobin', }
+      }
+    end
+
+    it { should contain_concat__fragment('haproxy-test_defaults_block').with(
+      'order'   => '25-test',
+      'target'  => '/tmp/haproxy.cfg',
+      'content' => "\n\ndefaults test\n  balance roundrobin\n"
+    ) }
+  end
+end

--- a/spec/defines/frontend_spec.rb
+++ b/spec/defines/frontend_spec.rb
@@ -262,6 +262,22 @@ describe 'haproxy::frontend' do
     ) }
   end
 
+  context "when defaults parameter is used with option default_backend" do
+    let(:params) do
+      {
+        :name     => 'apache',
+        :bind     => {'1.1.1.1:80' => []},
+        :defaults => 'test',
+        :options  => { 'default_backend' => 'b1' },
+      }
+    end
+    it { should contain_concat__fragment('haproxy-apache_frontend_block').with(
+      'order'   => '25-test-b1-00-apache',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "\nfrontend apache\n  bind 1.1.1.1:80 \n  default_backend b1\n"
+    ) }
+  end
+
   context "when configurung custom options for stick-tables" do
     let(:title) { 'baz' }
     let(:buzz) { 'type string len 180 size 32m expire 5m store http_req_rate(10s)' }

--- a/templates/haproxy_defaults_block.erb
+++ b/templates/haproxy_defaults_block.erb
@@ -1,0 +1,4 @@
+
+
+defaults <%= @name %>
+<%= scope.function_template(['haproxy/fragments/_options.erb']) -%>


### PR DESCRIPTION
If there is interest in this feature I will add documentation and spec tests. The patch add the option to use multiple defaults section, as described in the haproxy documentation:

> A "defaults" section sets default parameters for all other sections following
> its declaration. Those default parameters are reset by the next "defaults"
> section. See below for the list of parameters which can be set in a "defaults"
> section. The name is optional but its use is encouraged for better readability.

It's completely optional. Additionally if defaults are used, then the frontend and backend section are kept together in the haproxy configuration file if the frontend has the option `default_backend` or the frontend and backend are identical named. We are using multiple defaults and the improved ordering to improve the readability in our very long haproxy configuration files.
