### PR TITLE
Feature/make configvalidation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,8 @@ Main class, includes all other classes.
 
 * `config_dir`: Path to the directory in which the main configuration file `haproxy.cfg` resides. Will also be used for storing any managed map files (see [`haproxy::mapfile`](#define-haproxymapfile). Default depends on platform.
 
+* `config_validate`: Validate the HaProxy configuration before applying the changes. Use `undef` to disable the validation. Default: `/usr/sbin/haproxy -f %`
+
 #### Class: `haproxy::globals`
 
 For global configuration options used by all haproxy instances.

--- a/README.md
+++ b/README.md
@@ -561,7 +561,9 @@ Main class, includes all other classes.
 
 * `config_dir`: Path to the directory in which the main configuration file `haproxy.cfg` resides. Will also be used for storing any managed map files (see [`haproxy::mapfile`](#define-haproxymapfile). Default depends on platform.
 
-* `config_validate`: Validate the HaProxy configuration before applying the changes. Use `undef` or empty string to disable the validation. Default: `/usr/sbin/haproxy -f %`
+* `config_validate`: Validate the HaProxy configuration before applying the changes. Requires the 'config_validate_path' variable. Default: 'true'.
+
+* `config_validate_path`: Path to HaProxy validation script. Default: `/usr/sbin/haproxy -f %`.
 
 #### Class: `haproxy::globals`
 

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ Main class, includes all other classes.
 
 * `config_dir`: Path to the directory in which the main configuration file `haproxy.cfg` resides. Will also be used for storing any managed map files (see [`haproxy::mapfile`](#define-haproxymapfile). Default depends on platform.
 
-* `config_validate`: Validate the HaProxy configuration before applying the changes. Use `undef` to disable the validation. Default: `/usr/sbin/haproxy -f %`
+* `config_validate`: Validate the HaProxy configuration before applying the changes. Use `undef` or empty string to disable the validation. Default: `/usr/sbin/haproxy -f %`
 
 #### Class: `haproxy::globals`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,7 @@ define haproxy::config (
   $custom_fragment = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   $merge_options = $haproxy::merge_options,
   $config_validate = $haproxy::config_validate,
+  $config_validate_path = $haproxy::config_validate_path,
 ) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
@@ -37,11 +38,20 @@ define haproxy::config (
     $_config_file = $haproxy::config_file
   }
 
-  concat { $_config_file:
-    owner        => '0',
-    group        => '0',
-    mode         => '0644',
-    validate_cmd => $config_validate,
+
+  if $config_validate and $config_validate_path != undef {
+    concat { $_config_file:
+      owner        => '0',
+      group        => '0',
+      mode         => '0644',
+      validate_cmd => $config_validate_path,
+    }
+  } else {
+    concat { $_config_file:
+      owner        => '0',
+      group        => '0',
+      mode         => '0644',
+    }
   }
 
   # Simple Header

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,7 @@ define haproxy::config (
   $config_dir = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   $custom_fragment = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   $merge_options = $haproxy::merge_options,
+  $config_validate = $haproxy::config_validate,
 ) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
@@ -40,7 +41,7 @@ define haproxy::config (
     owner        => '0',
     group        => '0',
     mode         => '0644',
-    validate_cmd => '/usr/sbin/haproxy -f %',
+    validate_cmd => $config_validate,
   }
 
   # Simple Header

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,9 +48,9 @@ define haproxy::config (
     }
   } else {
     concat { $_config_file:
-      owner        => '0',
-      group        => '0',
-      mode         => '0644',
+      owner => '0',
+      group => '0',
+      mode  => '0644',
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,13 @@
 #   resides. Will also be used for storing any managed map files (see
 #   `haproxy::mapfile`). Default depends on platform.
 #
+#[*config_validate*]
+#  Boolean value to enable/disable config validation. Validation requires the 
+#  'config_validate_path'.
+#
+#[*config_validate_path*]
+#  Path to the HaProxy validation binary. 
+#
 # === Examples
 #
 #  class { 'haproxy':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,19 +102,20 @@
 #  }
 #
 class haproxy (
-  $package_ensure   = 'present',
-  $package_name     = $haproxy::params::package_name,
-  $service_ensure   = 'running',
-  $service_manage   = true,
-  $service_options  = $haproxy::params::service_options,
-  $global_options   = $haproxy::params::global_options,
-  $defaults_options = $haproxy::params::defaults_options,
-  $merge_options    = $haproxy::params::merge_options,
-  $restart_command  = undef,
-  $custom_fragment  = undef,
-  $config_dir       = $haproxy::params::config_dir,
-  $config_file      = $haproxy::params::config_file,
-  $config_validate  = $haproxy::params::config_validate,
+  $package_ensure        = 'present',
+  $package_name          = $haproxy::params::package_name,
+  $service_ensure        = 'running',
+  $service_manage        = true,
+  $service_options       = $haproxy::params::service_options,
+  $global_options        = $haproxy::params::global_options,
+  $defaults_options      = $haproxy::params::defaults_options,
+  $merge_options         = $haproxy::params::merge_options,
+  $restart_command       = undef,
+  $custom_fragment       = undef,
+  $config_dir            = $haproxy::params::config_dir,
+  $config_file           = $haproxy::params::config_file,
+  $config_validate       = $haproxy::params::config_validate,
+  $config_validate_path  = $haproxy::params::config_validate_path,
 
   # Deprecated
   $manage_service   = undef,
@@ -132,7 +133,8 @@ class haproxy (
   validate_string($service_options)
   validate_hash($global_options, $defaults_options)
   validate_absolute_path($config_dir)
-  validate_string($config_validate)
+  validate_bool($config_validate)
+  validate_string($config_validate_path)
 
   # NOTE: These deprecating parameters are implemented in this class,
   # not in haproxy::instance.  haproxy::instance is new and therefore
@@ -163,19 +165,20 @@ class haproxy (
   }
 
   haproxy::instance{ $title:
-    package_ensure   => $_package_ensure,
-    package_name     => $package_name,
-    service_ensure   => $_service_ensure,
-    service_manage   => $_service_manage,
-    global_options   => $global_options,
-    defaults_options => $defaults_options,
-    restart_command  => $restart_command,
-    custom_fragment  => $custom_fragment,
-    config_dir       => $config_dir,
-    config_file      => $config_file,
-    merge_options    => $merge_options,
-    service_options  => $service_options,
-    config_validate  => $config_validate,
+    package_ensure        => $_package_ensure,
+    package_name          => $package_name,
+    service_ensure        => $_service_ensure,
+    service_manage        => $_service_manage,
+    global_options        => $global_options,
+    defaults_options      => $defaults_options,
+    restart_command       => $restart_command,
+    custom_fragment       => $custom_fragment,
+    config_dir            => $config_dir,
+    config_file           => $config_file,
+    merge_options         => $merge_options,
+    service_options       => $service_options,
+    config_validate       => $config_validate,
+    config_validate_path  => $config_validate_path,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,12 +71,12 @@
 #   resides. Will also be used for storing any managed map files (see
 #   `haproxy::mapfile`). Default depends on platform.
 #
-#[*config_validate*]
-#  Boolean value to enable/disable config validation. Validation requires the 
-#  'config_validate_path'.
+# [*config_validate*]
+#   Boolean value to enable/disable config validation. Validation requires the 
+#   'config_validate_path'.
 #
-#[*config_validate_path*]
-#  Path to the HaProxy validation binary. 
+# [*config_validate_path*]
+#   Path to the HaProxy validation binary. 
 #
 # === Examples
 #
@@ -172,20 +172,20 @@ class haproxy (
   }
 
   haproxy::instance{ $title:
-    package_ensure        => $_package_ensure,
-    package_name          => $package_name,
-    service_ensure        => $_service_ensure,
-    service_manage        => $_service_manage,
-    global_options        => $global_options,
-    defaults_options      => $defaults_options,
-    restart_command       => $restart_command,
-    custom_fragment       => $custom_fragment,
-    config_dir            => $config_dir,
-    config_file           => $config_file,
-    merge_options         => $merge_options,
-    service_options       => $service_options,
-    config_validate       => $config_validate,
-    config_validate_path  => $config_validate_path,
+    package_ensure       => $_package_ensure,
+    package_name         => $package_name,
+    service_ensure       => $_service_ensure,
+    service_manage       => $_service_manage,
+    global_options       => $global_options,
+    defaults_options     => $defaults_options,
+    restart_command      => $restart_command,
+    custom_fragment      => $custom_fragment,
+    config_dir           => $config_dir,
+    config_file          => $config_file,
+    merge_options        => $merge_options,
+    service_options      => $service_options,
+    config_validate      => $config_validate,
+    config_validate_path => $config_validate_path,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,6 +114,7 @@ class haproxy (
   $custom_fragment  = undef,
   $config_dir       = $haproxy::params::config_dir,
   $config_file      = $haproxy::params::config_file,
+  $config_validate  = $haproxy::params::config_validate,
 
   # Deprecated
   $manage_service   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,6 +132,7 @@ class haproxy (
   validate_string($service_options)
   validate_hash($global_options, $defaults_options)
   validate_absolute_path($config_dir)
+  validate_string($config_validate)
 
   # NOTE: These deprecating parameters are implemented in this class,
   # not in haproxy::instance.  haproxy::instance is new and therefore

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,6 +175,7 @@ class haproxy (
     config_file      => $config_file,
     merge_options    => $merge_options,
     service_options  => $service_options,
+    config_validate  => $config_validate,
   }
 
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -135,19 +135,20 @@
 #  call haproxy::instance_service.
 #
 define haproxy::instance (
-  $package_ensure   = 'present',
-  $package_name     = undef,
-  $service_ensure   = 'running',
-  $service_manage   = true,
-  $global_options   = undef,
-  $defaults_options = undef,
-  $restart_command  = undef,
-  $custom_fragment  = undef,
-  $config_dir       = undef,
-  $config_file      = undef,
-  $merge_options    = $haproxy::params::merge_options,
-  $service_options  = $haproxy::params::service_options,
-  $config_validate  = $haproxy::params::config_validate,
+  $package_ensure        = 'present',
+  $package_name          = undef,
+  $service_ensure        = 'running',
+  $service_manage        = true,
+  $global_options        = undef,
+  $defaults_options      = undef,
+  $restart_command       = undef,
+  $custom_fragment       = undef,
+  $config_dir            = undef,
+  $config_file           = undef,
+  $merge_options         = $haproxy::params::merge_options,
+  $service_options       = $haproxy::params::service_options,
+  $config_validate       = $haproxy::params::config_validate,
+  $config_validate_path  = $haproxy::params::config_validate_path,
 ) {
 
   if $service_ensure != true and $service_ensure != false {
@@ -199,14 +200,16 @@ define haproxy::instance (
   }
 
   haproxy::config { $title:
-    instance_name    => $instance_name,
-    config_dir       => $_config_dir,
-    config_file      => $_config_file,
-    global_options   => $_global_options,
-    defaults_options => $_defaults_options,
-    custom_fragment  => $custom_fragment,
-    merge_options    => $merge_options,
-    config_validate  => $config_validate,
+    instance_name         => $instance_name,
+    config_dir            => $_config_dir,
+    config_file           => $_config_file,
+    global_options        => $_global_options,
+    defaults_options      => $_defaults_options,
+    custom_fragment       => $custom_fragment,
+    merge_options         => $merge_options,
+    config_validate       => $config_validate,
+    config_validate_path  => $config_validate_path,
+
   }
   haproxy::install { $title:
     package_name   => $package_name,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -147,6 +147,7 @@ define haproxy::instance (
   $config_file      = undef,
   $merge_options    = $haproxy::params::merge_options,
   $service_options  = $haproxy::params::service_options,
+  $config_validate  = $haproxy::params::config_validate,
 ) {
 
   if $service_ensure != true and $service_ensure != false {
@@ -205,6 +206,7 @@ define haproxy::instance (
     defaults_options => $_defaults_options,
     custom_fragment  => $custom_fragment,
     merge_options    => $merge_options,
+    config_validate  => $config_validate,
   }
   haproxy::install { $title:
     package_name   => $package_name,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -142,20 +142,20 @@
 #  call haproxy::instance_service.
 #
 define haproxy::instance (
-  $package_ensure        = 'present',
-  $package_name          = undef,
-  $service_ensure        = 'running',
-  $service_manage        = true,
-  $global_options        = undef,
-  $defaults_options      = undef,
-  $restart_command       = undef,
-  $custom_fragment       = undef,
-  $config_dir            = undef,
-  $config_file           = undef,
-  $merge_options         = $haproxy::params::merge_options,
-  $service_options       = $haproxy::params::service_options,
-  $config_validate       = $haproxy::params::config_validate,
-  $config_validate_path  = $haproxy::params::config_validate_path,
+  $package_ensure       = 'present',
+  $package_name         = undef,
+  $service_ensure       = 'running',
+  $service_manage       = true,
+  $global_options       = undef,
+  $defaults_options     = undef,
+  $restart_command      = undef,
+  $custom_fragment      = undef,
+  $config_dir           = undef,
+  $config_file          = undef,
+  $merge_options        = $haproxy::params::merge_options,
+  $service_options      = $haproxy::params::service_options,
+  $config_validate      = $haproxy::params::config_validate,
+  $config_validate_path = $haproxy::params::config_validate_path,
 ) {
 
   if $service_ensure != true and $service_ensure != false {

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -63,6 +63,13 @@
 #    The parent directory will be created automatically.
 #  Defaults to undef.
 #
+#[*config_validate*]
+#  Boolean value to enable/disable config validation. Validation requires the 
+#  'config_validate_path'.
+#
+#[*config_validate_path*]
+#  Path to the HaProxy validation binary. 
+#
 # === Examples
 #
 # A single instance of haproxy with all defaults

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -207,15 +207,15 @@ define haproxy::instance (
   }
 
   haproxy::config { $title:
-    instance_name         => $instance_name,
-    config_dir            => $_config_dir,
-    config_file           => $_config_file,
-    global_options        => $_global_options,
-    defaults_options      => $_defaults_options,
-    custom_fragment       => $custom_fragment,
-    merge_options         => $merge_options,
-    config_validate       => $config_validate,
-    config_validate_path  => $config_validate_path,
+    instance_name        => $instance_name,
+    config_dir           => $_config_dir,
+    config_file          => $_config_file,
+    global_options       => $_global_options,
+    defaults_options     => $_defaults_options,
+    custom_fragment      => $custom_fragment,
+    merge_options        => $merge_options,
+    config_validate      => $config_validate,
+    config_validate_path => $config_validate_path,
 
   }
   haproxy::install { $title:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,6 +44,7 @@ class haproxy::params {
       # Multi-instance:
       $config_dir_tmpl  = '/etc/<%= @instance_name %>'
       $config_file_tmpl = "${config_dir_tmpl}/<%= @instance_name %>.cfg"
+      $config_validate  = '/usr/sbin/haproxy -f %'
     }
     'FreeBSD': {
       $package_name     = 'haproxy'
@@ -77,6 +78,7 @@ class haproxy::params {
       # Multi-instance:
       $config_dir_tmpl  = '/usr/local/etc/<%= @instance_name %>'
       $config_file_tmpl = "${config_dir_tmpl}/<%= @instance_name %>.conf"
+      $config_validate  = '/usr/sbin/haproxy -f %'
     }
     default: { fail("The ${::osfamily} operating system is not supported with the haproxy module") }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,12 +39,13 @@ class haproxy::params {
         'maxconn' => '8000'
       }
       # Single instance:
-      $config_dir       = '/etc/haproxy'
-      $config_file      = '/etc/haproxy/haproxy.cfg'
+      $config_dir            = '/etc/haproxy'
+      $config_file           = '/etc/haproxy/haproxy.cfg'
       # Multi-instance:
-      $config_dir_tmpl  = '/etc/<%= @instance_name %>'
-      $config_file_tmpl = "${config_dir_tmpl}/<%= @instance_name %>.cfg"
-      $config_validate  = '/usr/sbin/haproxy -f %'
+      $config_dir_tmpl       = '/etc/<%= @instance_name %>'
+      $config_file_tmpl      = "${config_dir_tmpl}/<%= @instance_name %>.cfg"
+      $config_validate       = true
+      $config_validate_path  = '/usr/sbin/haproxy -f %'
     }
     'FreeBSD': {
       $package_name     = 'haproxy'
@@ -73,12 +74,13 @@ class haproxy::params {
         'srvtimeout' => '50000',
       }
       # Single instance:
-      $config_dir       = '/usr/local/etc'
-      $config_file      = '/usr/local/etc/haproxy.conf'
+      $config_dir            = '/usr/local/etc'
+      $config_file           = '/usr/local/etc/haproxy.conf'
       # Multi-instance:
-      $config_dir_tmpl  = '/usr/local/etc/<%= @instance_name %>'
-      $config_file_tmpl = "${config_dir_tmpl}/<%= @instance_name %>.conf"
-      $config_validate  = '/usr/sbin/haproxy -f %'
+      $config_dir_tmpl       = '/usr/local/etc/<%= @instance_name %>'
+      $config_file_tmpl      = "${config_dir_tmpl}/<%= @instance_name %>.conf"
+      $config_validate       = true
+      $config_validate_path  = '/usr/sbin/haproxy -f %'
     }
     default: { fail("The ${::osfamily} operating system is not supported with the haproxy module") }
   }


### PR DESCRIPTION
We had an issue with the validation of the haproxy(1.5.8-3) configuration on Debian(7.10) 
It was no able to validate as long the haproxy was running. 

`Starting proxy HOSTNAME: cannot bind socket [xx.xx.xx.xx:80]`