### PR TITLE
(MODULES-3412) Use haproxy::config_file instead of default config_file

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -77,7 +77,7 @@ define haproxy::backend (
   include ::haproxy::params
   if $instance == 'haproxy' {
     $instance_name = 'haproxy'
-    $config_file = $haproxy::params::config_file
+    $config_file = $haproxy::config_file
   } else {
     $instance_name = "haproxy-${instance}"
     $config_file = inline_template($haproxy::params::config_file_tmpl)

--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -91,7 +91,7 @@ define haproxy::balancermember (
   include haproxy::params
   if $instance == 'haproxy' {
     $instance_name = 'haproxy'
-    $config_file = $haproxy::params::config_file
+    $config_file = $haproxy::config_file
   } else {
     $instance_name = "haproxy-${instance}"
     $config_file = inline_template($haproxy::params::config_file_tmpl)

--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -102,7 +102,7 @@ define haproxy::frontend (
   include haproxy::params
   if $instance == 'haproxy' {
     $instance_name = 'haproxy'
-    $config_file = $haproxy::params::config_file
+    $config_file = $haproxy::config_file
   } else {
     $instance_name = "haproxy-${instance}"
     $config_file = inline_template($haproxy::params::config_file_tmpl)

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -117,7 +117,7 @@ define haproxy::listen (
   include haproxy::params
   if $instance == 'haproxy' {
     $instance_name = 'haproxy'
-    $config_file = $haproxy::params::config_file
+    $config_file = $haproxy::config_file
   } else {
     $instance_name = "haproxy-${instance}"
     $config_file = inline_template($haproxy::params::config_file_tmpl)

--- a/manifests/userlist.pp
+++ b/manifests/userlist.pp
@@ -36,7 +36,7 @@ define haproxy::userlist (
   include haproxy::params
   if $instance == 'haproxy' {
     $instance_name = 'haproxy'
-    $config_file = $haproxy::params::config_file
+    $config_file = $haproxy::config_file
   } else {
     $instance_name = "haproxy-${instance}"
     $config_file = inline_template($haproxy::params::config_file_tmpl)

--- a/spec/defines/backend_spec.rb
+++ b/spec/defines/backend_spec.rb
@@ -48,5 +48,22 @@ describe 'haproxy::backend' do
     end
   end
 
+  context "when a non-default config file is used" do
+    let(:pre_condition) { 'class { "haproxy": config_file => "/etc/non-default.cfg" }' }
+    let(:title) { 'baz' }
+    let(:params) do
+      {
+        :options => {
+          'balance' => 'roundrobin',
+        },
+      }
+    end
+    it { should contain_concat__fragment('haproxy-baz_backend_block').with(
+      'order' => '20-baz-00',
+      'target' => '/etc/non-default.cfg',
+      'content' => "\nbackend baz\n  balance roundrobin\n",
+    ) }
+  end
+
   # C9956 WONTFIX
 end

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -116,4 +116,21 @@ describe 'haproxy::balancermember' do
       'content' => "  server server01 192.168.56.200 check\n  server server02 192.168.56.201 check\n"
     ) }
   end
+  context "when a non-default config file is used" do
+    let(:pre_condition) { 'class { "haproxy": config_file => "/etc/non-default.cfg" }' }
+    let(:params) do
+      {
+        :name              => 'haproxy',
+        :listening_service => 'baz',
+        :server_names      => ['server01', 'server02'],
+        :ipaddresses       => ['10.0.0.1', '10.0.0.2'],
+        :options           => ['check']
+      }
+    end
+    it { should contain_concat__fragment('haproxy-baz_balancermember_haproxy').with(
+      'order' => '20-baz-01-haproxy',
+      'target' => '/etc/non-default.cfg',
+      'content' => "  server server01 10.0.0.1 check\n  server server02 10.0.0.2 check\n",
+    ) }
+  end
 end

--- a/spec/defines/frontend_spec.rb
+++ b/spec/defines/frontend_spec.rb
@@ -278,5 +278,27 @@ describe 'haproxy::frontend' do
     ) }
   end
 
+  context "when a non-default config file is used" do
+    let(:pre_condition) { 'class { "haproxy": config_file => "/etc/non-default.cfg" }' }
+    let(:params) do
+      {
+        :name => 'bar',
+        :bind => {
+          '*:5000' => [],
+        },
+        :options => {
+          'option' => [
+            'tcplog',
+          ],
+        },
+      }
+    end
+    it { should contain_concat__fragment('haproxy-bar_frontend_block').with(
+      'order' => '15-bar-00',
+      'target' => '/etc/non-default.cfg',
+      'content' => "\nfrontend bar\n  bind *:5000 \n  option tcplog\n",
+    ) }
+  end
+
   # C9950 C9951 C9952 WONTFIX
 end

--- a/spec/defines/listen_spec.rb
+++ b/spec/defines/listen_spec.rb
@@ -347,4 +347,27 @@ describe 'haproxy::listen' do
     ) }
   end
 
+  context "when a non-default config file is used" do
+    let(:pre_condition) { 'class { "haproxy": config_file => "/etc/non-default.cfg" }' }
+    let(:params) do
+      {
+        :name => 'bar',
+        :bind => {
+          '*:5000' => [],
+        },
+        :options => {
+          'option' => [
+            'tcplog',
+          ],
+          'balance' => 'roundrobin',
+        },
+      }
+    end
+    it { should contain_concat__fragment('haproxy-bar_listen_block').with(
+      'order' => '20-bar-00',
+      'target' => '/etc/non-default.cfg',
+      'content' => "\nlisten bar\n  bind *:5000 \n  balance roundrobin\n  option tcplog\n",
+    ) }
+  end
+
 end

--- a/spec/defines/userlist_spec.rb
+++ b/spec/defines/userlist_spec.rb
@@ -33,4 +33,24 @@ describe 'haproxy::userlist' do
     ) }
 
   end
+
+  context "when a non-default config file is used" do
+    let(:pre_condition) { 'class { "haproxy": config_file => "/etc/non-default.cfg" }' }
+    let(:params) do
+      {
+        :name => 'bar',
+        :users => [
+          'scott insecure-password elgato',
+        ],
+        :groups => [
+          'superuser users scott',
+        ],
+      }
+    end
+    it { should contain_concat__fragment('haproxy-bar_userlist_block').with(
+      'order' => '12-bar-00',
+      'target' => '/etc/non-default.cfg',
+      'content' => "\nuserlist bar\n  group superuser users scott\n  user scott insecure-password elgato\n",
+    ) }
+  end
 end


### PR DESCRIPTION
Custom haproxy::config_file is invalid for some resource types, such as haproxy::frontend and haproxy::backend, because variable config_file in those resource types are always from haproxy::params::config_file.

```puppet
class { 'haproxy':
  config_file => /path/to/haproxy.cfg
}
haproxy::frontend { 'main':
  mode => 'http',
  bind => { '*:8080' => '' },
  options => {
    default_backend => 'app',
  }
}
```

https://tickets.puppetlabs.com/browse/MODULES-3412