### PR TITLE
(maint) removes default-server keyword from test

### DIFF
--- a/spec/acceptance/defaults_spec.rb
+++ b/spec/acceptance/defaults_spec.rb
@@ -23,7 +23,6 @@ describe "frontend backend defines with defaults" do
           'timeout http-request' => '2s',
           balance => 'roundrobin',
           'maxconn' => '8000',
-          'default-server' => 'weight 100 inter 6s fastinter 1s downinter 3s fall 2 rise 4',
 
         }
       }
@@ -81,7 +80,6 @@ describe "frontend backend defines with defaults" do
           'timeout http-request' => '2s',
           balance => 'roundrobin',
           'maxconn' => '8000',
-          'default-server' => 'weight 100 inter 6s fastinter 1s downinter 3s fall 2 rise 4',
 
         }
       }


### PR DESCRIPTION
The default-server keyword is not supported in HAProxy version less
than 1.4.

This fixes a test failure on older versions of RedHat that install version 1.3.x that was Introduced by #232 