### PR TITLE
Add /etc/sysconfig/haproxy(instance_name) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,8 @@ Main class, includes all other classes.
 
 * `service_options`: Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
 
+* `sysconfig_options`: Contents for the `/etc/sysconfig/haproxy` file on RedHat(-based) systems. Defaults to OPTIONS="" on RedHat(-based) systems and is ignored on others
+
 * `config_dir`: Path to the directory in which the main configuration file `haproxy.cfg` resides. Will also be used for storing any managed map files (see [`haproxy::mapfile`](#define-haproxymapfile). Default depends on platform.
 
 #### Class: `haproxy::globals`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,6 +107,7 @@ class haproxy (
   $service_ensure    = 'running',
   $service_manage    = true,
   $service_options   = $haproxy::params::service_options,
+  $sysconfig_options = $haproxy::params::sysconfig_options,
   $global_options    = $haproxy::params::global_options,
   $defaults_options  = $haproxy::params::defaults_options,
   $merge_options     = $haproxy::params::merge_options,
@@ -162,18 +163,19 @@ class haproxy (
   }
 
   haproxy::instance{ $title:
-    package_ensure   => $_package_ensure,
-    package_name     => $package_name,
-    service_ensure   => $_service_ensure,
-    service_manage   => $_service_manage,
-    global_options   => $global_options,
-    defaults_options => $defaults_options,
-    restart_command  => $restart_command,
-    custom_fragment  => $custom_fragment,
-    config_dir       => $config_dir,
-    config_file      => $config_file,
-    merge_options    => $merge_options,
-    service_options  => $service_options,
+    package_ensure    => $_package_ensure,
+    package_name      => $package_name,
+    service_ensure    => $_service_ensure,
+    service_manage    => $_service_manage,
+    global_options    => $global_options,
+    defaults_options  => $defaults_options,
+    restart_command   => $restart_command,
+    custom_fragment   => $custom_fragment,
+    config_dir        => $config_dir,
+    config_file       => $config_file,
+    merge_options     => $merge_options,
+    service_options   => $service_options,
+    sysconfig_options => $sysconfig_options,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,11 +30,8 @@
 # [*service_options*]
 #   Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
 #
-# [*service_options*]
-#   Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
-#
-# [*service_options*]
-#   Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
+# [*sysconfig_options*]
+#   Contents for the `/etc/sysconfig/haproxy` file on RedHat(-based) systems. Defaults to OPTIONS="" on RedHat(-based) systems and is ignored on others
 #
 # [*global_options*]
 #   A hash of all the haproxy global options. If you want to specify more

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -135,18 +135,19 @@
 #  call haproxy::instance_service.
 #
 define haproxy::instance (
-  $package_ensure   = 'present',
-  $package_name     = undef,
-  $service_ensure   = 'running',
-  $service_manage   = true,
-  $global_options   = undef,
-  $defaults_options = undef,
-  $restart_command  = undef,
-  $custom_fragment  = undef,
-  $config_dir       = undef,
-  $config_file      = undef,
-  $merge_options    = $haproxy::params::merge_options,
-  $service_options  = $haproxy::params::service_options,
+  $package_ensure    = 'present',
+  $package_name      = undef,
+  $service_ensure    = 'running',
+  $service_manage    = true,
+  $global_options    = undef,
+  $defaults_options  = undef,
+  $restart_command   = undef,
+  $custom_fragment   = undef,
+  $config_dir        = undef,
+  $config_file       = undef,
+  $merge_options     = $haproxy::params::merge_options,
+  $service_options   = $haproxy::params::service_options,
+  $sysconfig_options = $haproxy::params::sysconfig_options,
 ) {
 
   if $service_ensure != true and $service_ensure != false {
@@ -211,11 +212,12 @@ define haproxy::instance (
     package_ensure => $package_ensure,
   }
   haproxy::service { $title:
-    instance_name   => $instance_name,
-    service_ensure  => $service_ensure,
-    service_manage  => $service_manage,
-    restart_command => $restart_command,
-    service_options => $service_options,
+    instance_name     => $instance_name,
+    service_ensure    => $service_ensure,
+    service_manage    => $service_manage,
+    restart_command   => $restart_command,
+    service_options   => $service_options,
+    sysconfig_options => $sysconfig_options,
   }
 
   if $package_ensure == 'absent' or $package_ensure == 'purged' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class haproxy::params {
   $merge_options = false
 
   $service_options  = "ENABLED=1\n"  # Only used by Debian.
+  $sysconfig_options = 'OPTIONS=""' #Only used by Redhat/CentOS etc
 
   case $::osfamily {
     'Archlinux', 'Debian', 'Redhat', 'Gentoo', 'Suse' : {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,6 +5,7 @@ define haproxy::service (
   $service_manage,
   $restart_command = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   $service_options = $haproxy::params::service_options,
+  $sysconfig_options = $haproxy::params::sysconfig_options,
 ) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,6 +17,12 @@ define haproxy::service (
         before  => Service[$instance_name],
       }
     }
+    if ($::osfamily == 'Redhat') {
+      file {"/etc/sysconfig/${instance_name}":
+        content => $sysconfig_options,
+        before  => Service[$instance_name],
+      }
+    }
 
     $_service_enable = $service_ensure ? {
         'running' => true,

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -566,6 +566,10 @@ describe 'haproxy::instance' do
         let(:facts) do
           { :osfamily => 'RedHat' }.merge default_facts
         end
+        it 'should manage haproxy sysconfig options' do
+          subject.should contain_file('/etc/sysconfig/haproxy-group1')
+          verify_contents(catalogue, '/etc/sysconfig/haproxy-group1', ['OPTIONS=""'])
+        end
       end
     end
   end


### PR DESCRIPTION
I found myself with the need to add a startup option to HAproxy (specifically, -L to set local peer name since on EL7 the supported HAproxy version truncates this to 32 characters), which can/should be done via /etc/sysconfig/haproxy (or, the instance name). 

This adds that parameter as a string, much like the Debian /etc/defaults equiv, and a test for it. 

Specs pass and tested IRL, and it works. 