### PR TITLE
(maint) disable selinux on acceptance test runs

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -15,6 +15,8 @@ RSpec.configure do |c|
     # Install module and dependencies
     puppet_module_install(:source => proj_root, :module_name => 'haproxy')
     hosts.each do |host|
+      disable_se_linux host
+
       on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','puppetlabs-concat'), { :acceptable_exit_codes => [0,1] }
       if fact('osfamily') == 'RedHat'


### PR DESCRIPTION
Need to disable selinux enforcement because on occassion selinux will
prevent the HAProxy service from restarting due to "too many restart attempts."