### PR TITLE
harden chmod of haproxy config file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,7 +46,7 @@ define haproxy::config (
     concat { $_config_file:
       owner        => '0',
       group        => '0',
-      mode         => '0644',
+      mode         => '0640',
       validate_cmd => '/usr/sbin/haproxy -f % -c',
     }
 

--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -62,7 +62,7 @@ describe 'haproxy', :type => :class do
             subject.should contain_concat('/etc/haproxy/haproxy.cfg').with(
               'owner' => '0',
               'group' => '0',
-              'mode'  => '0644'
+              'mode'  => '0640'
             )
           end
           it 'should manage the chroot directory' do
@@ -122,7 +122,7 @@ describe 'haproxy', :type => :class do
             subject.should contain_concat('/tmp/haproxy.cfg').with(
               'owner' => '0',
               'group' => '0',
-              'mode'  => '0644'
+              'mode'  => '0640'
             )
           end
         end
@@ -149,7 +149,7 @@ describe 'haproxy', :type => :class do
             subject.should contain_concat('/etc/haproxy/haproxy.cfg').with(
               'owner' => '0',
               'group' => '0',
-              'mode'  => '0644'
+              'mode'  => '0640'
             )
           end
           it 'should manage the chroot directory' do
@@ -221,7 +221,7 @@ describe 'haproxy', :type => :class do
           subject.should contain_concat('/usr/local/etc/haproxy.conf').with(
             'owner' => '0',
             'group' => '0',
-            'mode'  => '0644'
+            'mode'  => '0640'
           )
         end
         it 'should manage the chroot directory' do
@@ -283,7 +283,7 @@ describe 'haproxy', :type => :class do
           subject.should contain_concat('/usr/local/etc/haproxy.conf').with(
             'owner' => '0',
             'group' => '0',
-            'mode'  => '0644'
+            'mode'  => '0640'
           )
         end
         it 'should manage the chroot directory' do

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -71,7 +71,7 @@ describe 'haproxy::instance' do
             subject.should contain_concat('/etc/haproxy/haproxy.cfg').with(
               'owner' => '0',
               'group' => '0',
-              'mode'  => '0644'
+              'mode'  => '0640'
             )
           end
           it 'should manage the chroot directory' do
@@ -142,7 +142,7 @@ describe 'haproxy::instance' do
             subject.should contain_concat('/etc/haproxy/haproxy.cfg').with(
               'owner' => '0',
               'group' => '0',
-              'mode'  => '0644'
+              'mode'  => '0640'
             )
           end
           it 'should manage the chroot directory' do
@@ -271,7 +271,7 @@ describe 'haproxy::instance' do
             subject.should contain_concat('/etc/haproxy-group1/haproxy-group1.cfg').with(
               'owner' => '0',
               'group' => '0',
-              'mode'  => '0644'
+              'mode'  => '0640'
             )
           end
           it 'should manage the chroot directory' do
@@ -342,7 +342,7 @@ describe 'haproxy::instance' do
             subject.should contain_concat('/etc/haproxy-group1/haproxy-group1.cfg').with(
               'owner' => '0',
               'group' => '0',
-              'mode'  => '0644'
+              'mode'  => '0640'
             )
           end
           it 'should manage the chroot directory' do
@@ -417,7 +417,7 @@ describe 'haproxy::instance' do
           subject.should contain_concat('/usr/local/etc/haproxy.conf').with(
             'owner' => '0',
             'group' => '0',
-            'mode'  => '0644'
+            'mode'  => '0640'
           )
         end
         it 'should manage the chroot directory' do
@@ -480,7 +480,7 @@ describe 'haproxy::instance' do
           subject.should contain_concat('/usr/local/etc/haproxy.conf').with(
             'owner' => '0',
             'group' => '0',
-            'mode'  => '0644'
+            'mode'  => '0640'
           )
         end
         it 'should manage the chroot directory' do


### PR DESCRIPTION
it might be that the config file contains sensitive data (e.g.
https://cbonte.github.io/haproxy-dconv/1.5/configuration.html#4.2-stats%20auth )
and so it shouldn't be world readable.
