### PR TITLE
Don't attempt validate_cmd on Puppet < 3.5

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,9 +44,9 @@ define haproxy::config (
     file { $_config_file: ensure => absent }
   } else {
     concat { $_config_file:
-      owner        => '0',
-      group        => '0',
-      mode         => '0644',
+      owner => '0',
+      group => '0',
+      mode  => '0644',
     }
 
     # validate_cmd introduced in Puppet 3.5

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,7 +47,13 @@ define haproxy::config (
       owner        => '0',
       group        => '0',
       mode         => '0644',
-      validate_cmd => '/usr/sbin/haproxy -f % -c',
+    }
+
+    # validate_cmd introduced in Puppet 3.5
+    if versioncmp($::puppetversion, '3.5') >= 0 and ($::serverversion == undef or versioncmp($::serverversion, '3.5') >= 0) {
+      Concat[$_config_file] {
+        validate_cmd => '/usr/sbin/haproxy -f % -c'
+      }
     }
 
     # Simple Header

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,7 +50,7 @@ define haproxy::config (
     }
 
     # validate_cmd introduced in Puppet 3.5
-    if versioncmp($::puppetversion, '3.5') >= 0 and ($::serverversion == undef or versioncmp($::serverversion, '3.5') >= 0) {
+    if ((!defined('$::puppetversion') or (versioncmp($::puppetversion, '3.5') >= 0)) and (!defined('$::serverversion') or versioncmp($::serverversion, '3.5') >= 0)) {
       Concat[$_config_file] {
         validate_cmd => '/usr/sbin/haproxy -f % -c'
       }


### PR DESCRIPTION
This commit allows us to still run this module on Puppet < 3.5 as the validate_cmd function wasn't available until then, and avoid the error 'Error: Failed to apply catalog: Invalid parameter validate_cmd'.

I'd recommend leaving the Puppet 3.5 dependency in manifest.json, as Puppet 3.5 is pretty old. This is a workaround for us to prevent an error when bootstrapping Ubuntu Trusty machines until Puppet has upgraded itself to the puppetlabs repo version.
