### PR TITLE
Add verifyhost parameter to balancermember resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,8 @@ Configures a service inside a listening or backend service configuration block i
 
 * `config_file`: *Optional.* Path of the config file where this entry will be added. Assumes that the parent directory exists. Defaults to `haproxy::params::config_file`.
 
+* `verifyhost`: *Optional.* Will add the verifyhost option to the server line, using the specific host from server_names as an argument.  Defaults to false
+
 #### Define: `haproxy::backend`
 
 Sets up a backend service configuration block inside haproxy.cfg. Each backend service needs one or more balancermember services (declared with the [`haproxy::balancermember` define](#define-haproxybalancermember)).

--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -56,6 +56,11 @@
 #   Assumes that the parent directory exists.
 #   Default: $haproxy::params::config_file
 #
+# [*verifyhost*]
+#   Optional. Will add the verifyhost option to the server line, using the
+#   specific host from server_names as an argument.
+#   Default: false
+#
 # === Examples
 #
 #  Exporting the resource for a balancer member:
@@ -97,6 +102,7 @@ define haproxy::balancermember (
   $instance     = 'haproxy',
   $defaults     = undef,
   $config_file  = undef,
+  $verifyhost   = false,
 ) {
 
   include haproxy::params

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -63,6 +63,24 @@ describe 'haproxy::balancermember' do
       'content' => "  server dero 1.1.1.1:18140 cookie dero check close\n"
     ) }
   end
+
+  context 'with verifyhost' do
+    let(:params) do
+      {
+        :name              => 'tyler',
+        :listening_service => 'croy',
+        :ports             => '18140',
+        :options           => ['check', 'close'],
+        :verifyhost        => true
+      }
+    end
+
+    it { should contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
+      'order'   => '20-croy-01-tyler',
+      'target'  => '/etc/haproxy/haproxy.cfg',
+      'content' => "  server dero 1.1.1.1:18140 check close verifyhost dero\n"
+    ) }
+  end
   context 'with multiple servers' do
     let(:params) do
       {

--- a/templates/haproxy_balancermember.erb
+++ b/templates/haproxy_balancermember.erb
@@ -1,9 +1,9 @@
 <% Array(@ipaddresses).zip(Array(@server_names)).each do |ipaddress,host| -%>
 <% if @ports -%>
 <%- Array(@ports).each do |port| -%>
-  server <%= host %> <%= ipaddress %>:<%= port %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %>
+  server <%= host %> <%= ipaddress %>:<%= port %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %><% if @verifyhost == true %> verifyhost <%= host %><% end %>
 <%- end -%>
 <% else -%>
-  server <%= host %> <%= ipaddress %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %>
+  server <%= host %> <%= ipaddress %><%= if @define_cookies then " cookie " + host end %> <%= Array(@options).sort.join(" ") %><% if @verifyhost == true %> verifyhost <%= host %><% end %>
 <%- end -%>
 <% end -%>


### PR DESCRIPTION
The verifyhost parameter from haproxy [1] will attempt to match
the server's certificate CN or SubjectAltName, and will fail if
there is no match.

In the balancermember resource, it was added as a boolean, since it's
somewhat difficult to add the parameter to the options list, since
each hostname in the verifyhost will be different for each of the
servers in the server_names list. So, to address this, we now can
specify a boolean, and if it's set to true, it will use the host of
the specific server line and use it for the verifyhost option.

Note that this configuration only works if we are using HAProxy with
OpenSSL, and if we set up the 'ssl' and 'verify required' options in
the options of the servers.

[1] https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.2-verifyhost