### PR TITLE
added CentOS to acceptable OSes

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class haproxy::params {
   $sysconfig_options = 'OPTIONS=""' #Only used by Redhat/CentOS etc
 
   case $::osfamily {
-    'Archlinux', 'Debian', 'Redhat', 'Gentoo', 'Suse' : {
+    'Archlinux', 'Debian', 'Redhat', 'Gentoo', 'Suse', 'CentOS' : {
       $package_name      = 'haproxy'
       $global_options    = {
         'log'     => "${::ipaddress} local0",


### PR DESCRIPTION
Using this module on CentOS 7 gave an error:

`Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Resource type not found: Redhat at /etc/puppetlabs/code/environments/production/modules/haproxy/manifests/params.pp:9:5 on node
`

I added CentOS to the acceptable list of OSes under the same section as RedHat.