### PR TITLE
Change if $bind_options to if $bind_options != ''

### DIFF
--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -110,7 +110,7 @@ define haproxy::frontend (
   if $ipaddress and $bind {
     fail('The use of $ipaddress and $bind is mutually exclusive, please choose either one')
   }
-  if $bind_options {
+  if $bind_options != '' {
     warning('The $bind_options parameter is deprecated; please use $bind instead')
   }
   if $bind {


### PR DESCRIPTION
In puppet 4 the deprecated warning is triggered even when $bind_options is not set (''). This brings the frontend.pp if statement for this in line with the one in listen.pp.