### PR TITLE
Removing Debian 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]


### PR DESCRIPTION
This is no longer supported according to
https://docs.puppet.com/pe/latest/sys_req_os.html
Removing from metadata.json