### PR TITLE
bump allowed concat module version to 5.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name":"puppetlabs/concat",
-      "version_requirement": ">= 1.2.3 < 3.0.0"
+      "version_requirement": ">= 1.2.3 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
So it includes currently released version