### PR TITLE
Re-add support for specifying package version in package_ensure

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ Main class, includes all other classes.
 
 * `merge_options`: Whether to merge the user-supplied `global_options`/`defaults_options` hashes with their default values set in params.pp. Merging allows to change or add options without having to recreate the entire hash. Defaults to `false`, but will default to `true` in future releases.
 
-* `package_ensure`: Specifies whether the HAProxy package should exist. Defaults to 'present'. Valid options: 'present' and 'absent'. Default: 'present'.
+* `package_ensure`: Ensure the package is present (installed), absent or a specific version. Default: 'present'
 
 * `package_name`: Specifies the name of the HAProxy package. Valid options: a string. Default: 'haproxy'.
 
@@ -846,8 +846,8 @@ use the Class['haproxy'], which runs a single haproxy daemon on a machine.
 
 ##### Parameters
 
-* `package_ensure`: Chooses whether the haproxy package should be installed or uninstalled.
-Defaults to 'present'
+* `package_ensure`: Ensure the package is present (installed), absent or a
+specific version. Defaults to 'present'
 
 * `package_name`:
 The package name of haproxy. Defaults to undef, and no package is installed.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@
 # === Parameters
 #
 # [*package_ensure*]
-#   Chooses whether the haproxy package should be installed or uninstalled.
+#   Ensure the package is present (installed), absent or a specific version.
 #   Defaults to 'present'
 #
 # [*package_name*]
@@ -109,7 +109,7 @@
 #  }
 #
 class haproxy (
-  Enum['present', 'absent', 'latest'] $package_ensure          = 'present',
+  String[1] $package_ensure                                    = 'present',
   String $package_name                                         = $haproxy::params::package_name,
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure = 'running',
   Boolean $service_manage                                      = true,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -13,7 +13,7 @@
 # === Parameters
 #
 # [*package_ensure*]
-#   Chooses whether the haproxy package should be installed or uninstalled.
+#   Ensure the package is present (installed), absent or a specific version.
 #   Defaults to 'present'
 #
 # [*package_name*]
@@ -141,7 +141,7 @@
 #
 define haproxy::instance (
   Optional[String] $package_name                               = undef,
-  Enum['absent', 'latest', 'present'] $package_ensure          = 'present',
+  String[1] $package_ensure                                    = 'present',
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure = 'running',
   Boolean $service_manage                                      = true,
   Optional[Hash] $global_options                               = undef,

--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -34,6 +34,30 @@ describe 'haproxy', type: :class do
           )
         end
       end
+      context "on #{osfamily} specifying a package version" do
+        let(:facts) do
+          { osfamily: osfamily }.merge default_facts
+        end
+        let(:params) do
+          {
+            'service_ensure' => 'running',
+            'package_ensure' => '1.7.9-1',
+            'service_manage' => true,
+          }
+        end
+
+        it 'installs the haproxy package in a specific version' do
+          subject.should contain_package('haproxy').with(
+            'ensure' => '1.7.9-1',
+          )
+        end
+        it 'installs the haproxy service' do
+          subject.should contain_service('haproxy').with(
+            'ensure' => 'running', 'enable' => 'true',
+            'hasrestart' => 'true', 'hasstatus' => 'true'
+          )
+        end
+      end
       # C9938
       context "on #{osfamily} when specifying custom content" do
         let(:facts) do

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -45,6 +45,31 @@ describe 'haproxy::instance' do
             )
           end
         end
+        context "on #{osfamily} family specifying a package version" do
+          let(:facts) do
+            { osfamily: osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'service_ensure' => 'running',
+              'package_ensure' => '1.7.9-1',
+              'package_name'   => 'haproxy',
+              'service_manage' => true,
+            }
+          end
+
+          it 'installs the haproxy package in a specific version' do
+            subject.should contain_package('haproxy').with(
+              'ensure' => '1.7.9-1',
+            )
+          end
+          it 'installs the haproxy service' do
+            subject.should contain_service('haproxy').with(
+              'ensure' => 'running', 'enable' => 'true',
+              'hasrestart' => 'true', 'hasstatus' => 'true'
+            )
+          end
+        end
         # C9938
         context "on #{osfamily} when specifying custom content" do
           let(:facts) do


### PR DESCRIPTION
Restricting haproxy::package_ensure to one of 'present', 'absent' or
'latest' prevents the user from letting Puppet install a specific
version of the HAProxy package. This restriction is unwise. It is also
an unnecessary breaking change from version 1.5.0.

This commit replaces the Enum data type for haproxy::package_ensure
and haproxy::instance::package_ensure with the String data type, adds
spec tests for setting a specific package version and updates the
documentation.