### PR TITLE
Change bind_options default value

### DIFF
--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -102,7 +102,7 @@ define haproxy::frontend (
   $defaults_use_backend                        = true,
   Optional[Stdlib::Absolutepath] $config_file  = undef,
   # Deprecated
-  $bind_options                                = undef,
+  $bind_options                                = '',
 ) {
   if $ports and $bind {
     fail('The use of $ports and $bind is mutually exclusive, please choose either one')


### PR DESCRIPTION
Changing the default value to match the one found in listen.pp to stop invalid warning messages