### PR TITLE
(MODULES-8407) Add option to set the service's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     * [Beginning with haproxy](#beginning-with-haproxy)
 4. [Usage - Configuration options and additional functionality](#usage)
     * [Configure HAProxy options](#configure-haproxy-options)
+    * [HAProxy and Software Collections](#haproxy-and-software-collections)
     * [Configure HAProxy daemon listener](#configure-haproxy-daemon-listener)
     * [Configure multi-network daemon listener](#configure-multi-network-daemon-listener)
     * [Configure HAProxy load-balanced member nodes](#configure-haproxy-load-balanced-member-nodes)
@@ -125,6 +126,22 @@ class { 'haproxy':
     ],
     'maxconn' => '15000',
   },
+}
+~~~
+
+### HAProxy and Software Collections
+
+To use this module with a software collection such as
+[rh-haproxy18](https://www.softwarecollections.org/en/scls/rhscl/rh-haproxy18/)
+you will need to set a few extra parameters like so:
+
+~~~puppet
+class { 'haproxy':
+  package_name        => 'rh-haproxy18',
+  config_dir          => '/etc/opt/rh/rh-haproxy18/haproxy',
+  config_file         => '/etc/opt/rh/rh-haproxy18/haproxy/haproxy.cfg',
+  config_validate_cmd => '/bin/scl enable rh-haproxy18 "haproxy -f % -c"',
+  service_name        => 'rh-haproxy18-haproxy',
 }
 ~~~
 
@@ -599,6 +616,8 @@ Main class, includes all other classes.
 
 * `service_manage`: Specifies whether the state of the HAProxy service should be managed by Puppet. Valid options: 'true' and 'false'. Default: 'true'.
 
+* `service_name`: Specifies the name of the HAProxy service. Valid options: a string. Default: 'haproxy'.
+
 * `service_options`: Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
 
 * `sysconfig_options`: Contents for the `/etc/sysconfig/haproxy` file on RedHat(-based) systems. Defaults to OPTIONS="" on RedHat(-based) systems and is ignored on others
@@ -860,6 +879,11 @@ stopped and disabled at boot. Defaults to 'running'
 * `service_manage`:
 Chooses whether the haproxy service state should be managed by puppet at
 all. Defaults to true
+
+* `service_name`:
+The service name for haproxy. Defaults to undef. If no name is given then
+the value computed for $instance_name will be used.
+NOTE: Class['haproxy'] has a different default.
 
 * `global_options`:
 A hash of all the haproxy global options. If you want to specify more

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,10 @@
 #   Chooses whether the haproxy service state should be managed by puppet at
 #   all. Defaults to true
 #
+# [*service_name*]
+#   The service name for haproxy. Defaults to 'haproxy'
+#   NOTE: haproxy::instance has a different default.
+#
 # [*service_options*]
 #   Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
 #
@@ -113,6 +117,7 @@ class haproxy (
   String $package_name                                         = $haproxy::params::package_name,
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure = 'running',
   Boolean $service_manage                                      = true,
+  String $service_name                                         = $haproxy::params::service_name,
   String $service_options                                      = $haproxy::params::service_options,
   $sysconfig_options                                           = $haproxy::params::sysconfig_options,
   Hash $global_options                                         = $haproxy::params::global_options,
@@ -163,6 +168,7 @@ class haproxy (
     package_name        => $package_name,
     service_ensure      => $_service_ensure,
     service_manage      => $_service_manage,
+    service_name        => $service_name,
     global_options      => $global_options,
     defaults_options    => $defaults_options,
     restart_command     => $restart_command,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -28,6 +28,11 @@
 #   Chooses whether the haproxy service state should be managed by puppet at
 #   all. Defaults to true
 #
+# [*service_name*]
+#   The service name for haproxy. Defaults to undef. If no name is given then
+#   the value computed for $instance_name will be used.
+#   NOTE: Class['haproxy'] has a different default.
+#
 # [*global_options*]
 #   A hash of all the haproxy global options. If you want to specify more
 #    than one option (i.e. multiple timeout or stats options), pass those
@@ -144,6 +149,7 @@ define haproxy::instance (
   String[1] $package_ensure                                    = 'present',
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure = 'running',
   Boolean $service_manage                                      = true,
+  Optional[String] $service_name                               = undef,
   Optional[Hash] $global_options                               = undef,
   Optional[Hash] $defaults_options                             = undef,
   $restart_command                                             = undef,
@@ -188,6 +194,8 @@ define haproxy::instance (
     $_config_dir = pick($config_dir, inline_template($haproxy::params::config_dir_tmpl))
   }
 
+  $instance_service_name = pick($service_name, $instance_name)
+
   haproxy::config { $title:
     instance_name       => $instance_name,
     config_dir          => $_config_dir,
@@ -204,7 +212,7 @@ define haproxy::instance (
     package_ensure => $package_ensure,
   }
   haproxy::service { $title:
-    instance_name     => $instance_name,
+    instance_name     => $instance_service_name,
     service_ensure    => $service_ensure,
     service_manage    => $service_manage,
     restart_command   => $restart_command,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class haproxy::params {
   case $::osfamily {
     'Archlinux', 'Debian', 'Redhat', 'Gentoo', 'Suse' : {
       $package_name      = 'haproxy'
+      $service_name      = 'haproxy'
       $global_options    = {
         'log'     => "${::ipaddress} local0",
         'chroot'  => '/var/lib/haproxy',
@@ -50,6 +51,7 @@ class haproxy::params {
     }
     'FreeBSD': {
       $package_name      = 'haproxy'
+      $service_name      = 'haproxy'
       $global_options    = {
         'log'     => [
           '127.0.0.1 local0',


### PR DESCRIPTION
This is being added to support using the software collection for haproxy
on CentOS. Before this change both the name of the service being managed
and the sysconfig file for the service were incorrect and could not be
coaxed into a valid state.