### PR TITLE
(FM-7675) - Support has been removed for RHEL 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,6 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "5",
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
Please note that this is not as a result of loss of functionality but of our inability to continue to test the module against it due to the required mirror being lost.