### PR TITLE
(MODULES-8539) Added 'accepted_payload_size' to resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,18 +334,19 @@ class { 'haproxy':
 
 # Declare the resolver
 haproxy::resolver { 'puppet00':
-  nameservers     => {
+  nameservers           => {
     'dns1' => '192.168.56.1:53',
     'dns2' => '192.168.56.2:53'
   },
-  hold            => {
+  hold                  => {
     'nx'    => '30s',
     'valid' => '10s'
   },
-  resolve_retries => 3,
-  timeout         => {
+  resolve_retries       => 3,
+  timeout               => {
     'retry' => '1s'
   },
+  accepted_payload_size => 512,
 }
 
 # Setup the balancermember to use the resolver for DNS resolution

--- a/spec/defines/resolver_spec.rb
+++ b/spec/defines/resolver_spec.rb
@@ -18,6 +18,7 @@ describe 'haproxy::resolver' do
         hold: { 'other' => '30s', 'refused' => '30s', 'nx' => '30s', 'timeout' => '30s', 'valid' => '10s' },
         resolve_retries: 3,
         timeout: { 'retry' => '1s' },
+        accepted_payload_size: 512,
       }
     end
 
@@ -25,8 +26,38 @@ describe 'haproxy::resolver' do
       is_expected.to contain_concat__fragment('haproxy-bar_resolver_block').with(
         'order'   => '20-bar-01',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nresolvers bar\n  nameserver dns1 1.1.1.1:53\n  nameserver dns2 1.1.1.2:53\n  resolve_retries 3\n  timeout retry 1s\n  hold other 30s\n  hold refused 30s\n  hold nx 30s\n  hold timeout 30s\n  hold valid 10s\n", # rubocop:disable Metrics/LineLength
+        'content' => "\nresolvers bar\n  nameserver dns1 1.1.1.1:53\n  nameserver dns2 1.1.1.2:53\n  resolve_retries 3\n  timeout retry 1s\n  hold other 30s\n  hold refused 30s\n  hold nx 30s\n  hold timeout 30s\n  hold valid 10s\n  accepted_payload_size 512\n", # rubocop:disable Metrics/LineLength
       )
     }
+  end
+
+  context 'with accepted_payload_size too small' do
+    let(:title) { 'bar' }
+    let(:params) do
+      {
+        nameservers: { 'dns1' => '1.1.1.1:53', 'dns2' => '1.1.1.2:53' },
+        hold: { 'other' => '30s', 'refused' => '30s', 'nx' => '30s', 'timeout' => '30s', 'valid' => '10s' },
+        resolve_retries: 3,
+        timeout: { 'retry' => '1s' },
+        accepted_payload_size: 511,
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{accepted_payload_size must be atleast 512 and not more than 8192}) }
+  end
+
+  context 'with accepted_payload_size too large' do
+    let(:title) { 'bar' }
+    let(:params) do
+      {
+        nameservers: { 'dns1' => '1.1.1.1:53', 'dns2' => '1.1.1.2:53' },
+        hold: { 'other' => '30s', 'refused' => '30s', 'nx' => '30s', 'timeout' => '30s', 'valid' => '10s' },
+        resolve_retries: 3,
+        timeout: { 'retry' => '1s' },
+        accepted_payload_size: 8193,
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{accepted_payload_size must be atleast 512 and not more than 8192}) }
   end
 end

--- a/templates/haproxy_resolver_block.erb
+++ b/templates/haproxy_resolver_block.erb
@@ -10,3 +10,4 @@ resolvers <%= @section_name %>
 <% @hold.each do |status, period| -%>
   hold <%= status %> <%= period %>
 <% end -%>
+  accepted_payload_size <%= @accepted_payload_size %>


### PR DESCRIPTION
This paramter is defined in the HAProxy docs at
https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.3.2-accepted_payload_size
but was missing from this module. This commit adds
the ability to set the accepted_payload_size