### PR TITLE
Add check of OS for the systemd unitfile

### DIFF
--- a/manifests/instance_service.pp
+++ b/manifests/instance_service.pp
@@ -99,7 +99,7 @@ define haproxy::instance_service (
       }
 
       if $::osfamily == 'RedHat' {
-        $unitfile = "/usr/lib/systemd/system/haproxy-${title}.service" 
+        $unitfile = "/usr/lib/systemd/system/haproxy-${title}.service"
       } else {
         $unitfile = "/lib/systemd/system/haproxy-${title}.service"
       }

--- a/manifests/instance_service.pp
+++ b/manifests/instance_service.pp
@@ -99,11 +99,11 @@ define haproxy::instance_service (
       }
 
       if $::osfamily == 'RedHat' {
-        $unitfile = "/usr/lib/systemd/system/haproxy-${title}.service"  
+        $unitfile = "/usr/lib/systemd/system/haproxy-${title}.service" 
       } else {
-        $unitfile = "/lib/systemd/system/haproxy-${title}.service" 
+        $unitfile = "/lib/systemd/system/haproxy-${title}.service"
       }
-      
+
       file { $unitfile:
         ensure  => file,
         mode    => '0744',

--- a/manifests/instance_service.pp
+++ b/manifests/instance_service.pp
@@ -98,7 +98,12 @@ define haproxy::instance_service (
         $wrapper = "/opt/${haproxy_package}/sbin/haproxy-systemd-wrapper"
       }
 
-      $unitfile = "/usr/lib/systemd/system/haproxy-${title}.service"
+      if $::osfamily == 'RedHat' {
+        $unitfile = "/usr/lib/systemd/system/haproxy-${title}.service"  
+      } else {
+        $unitfile = "/lib/systemd/system/haproxy-${title}.service" 
+      }
+      
       file { $unitfile:
         ensure  => file,
         mode    => '0744',


### PR DESCRIPTION
As the [systemd.unit man page states on a Debian based OS](https://manpages.debian.org/stretch/systemd/systemd.unit.5.en.html), 
the unit files should be put in /lib/systemd/system  instead of /usr/lib/systemd/system, otherwise the module fails on Debian.