### PR TITLE
Ensure multiple instances may be created with the default package.

### DIFF
--- a/manifests/instance_service.pp
+++ b/manifests/instance_service.pp
@@ -39,7 +39,7 @@
 #
 define haproxy::instance_service (
   Optional[String] $haproxy_init_source  = undef,
-  Optional[String]$haproxy_unit_template = undef,
+  Optional[String]$haproxy_unit_template = 'haproxy/instance_service_unit.erb',
   String $haproxy_package                = 'haproxy',
   Stdlib::Absolutepath $bindir           = '/opt/haproxy/bin',
 ) {

--- a/manifests/instance_service.pp
+++ b/manifests/instance_service.pp
@@ -74,7 +74,7 @@ define haproxy::instance_service (
   # Create init.d or systemd files so that "service haproxy-$instance start"
   # or "systemd start haproxy-$instance" works.
   # This is not required if the standard instance is being used.
-  if ($title == 'haproxy') or ($haproxy_package == 'haproxy') {
+  if ($title == 'haproxy') and ($haproxy_package == 'haproxy') {
   } else {
     $initfile = "/etc/init.d/haproxy-${title}"
     if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {

--- a/spec/defines/instance_service_spec.rb
+++ b/spec/defines/instance_service_spec.rb
@@ -53,6 +53,11 @@ describe 'haproxy::instance_service' do
 
     context 'with title group1 and custom settings' do
       let(:title) { 'haproxy' }
+      let(:pre_condition) do
+        <<-PUPPETCODE
+        service {'haproxy-#{title}': }
+      PUPPETCODE
+      end
       let(:params) do
         {
           'haproxy_package'     => 'customhaproxy',

--- a/spec/defines/instance_service_spec.rb
+++ b/spec/defines/instance_service_spec.rb
@@ -99,6 +99,11 @@ describe 'haproxy::instance_service' do
 
     context 'with title group1 and defaults params' do
       let(:title) { 'group1' }
+      let(:pre_condition) do
+        <<-PUPPETCODE
+        service {'haproxy-#{title}': }
+      PUPPETCODE
+      end
       let(:params) do
         {
           'haproxy_init_source' => '/foo/bar',
@@ -144,7 +149,6 @@ describe 'haproxy::instance_service' do
         'haproxy_package'     => 'customhaproxy',
         'bindir'              => '/weird/place',
         'haproxy_init_source' => '/init/source/haproxy',
-        'haproxy_unit_template' => 'haproxy/instance_service_unit_example.erb',
       }
     end
 

--- a/templates/instance_service_unit.erb
+++ b/templates/instance_service_unit.erb
@@ -3,7 +3,11 @@ Description=HAProxy-<%= @title %> Load Balancer
 After=syslog.target network.target
 
 [Service]
+<% if @title == "haproxy" -%>
+ExecStart=<%= @wrapper %> -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
+<% else -%>
 ExecStart=<%= @wrapper %> -f /etc/haproxy-<%= @title %>/haproxy-<%= @title %>.cfg -p /run/haproxy-<%= @title %>.pid
+<% end %>
 ExecReload=/bin/kill -USR2 $MAINPID
 
 [Install]


### PR DESCRIPTION
In a scenario with multiple instances, the services' files won't be created if the default haproxy package is used.
The title itself MUST be different between the instances, but the package could be the same for all of them.

