### PR TITLE
(MODULES-8566) Only create entries for defined settings

### DIFF
--- a/templates/haproxy_resolver_block.erb
+++ b/templates/haproxy_resolver_block.erb
@@ -3,11 +3,19 @@ resolvers <%= @section_name %>
 <% @nameservers.each do |id, nameserver| -%>
   nameserver <%= id %> <%= nameserver %>
 <% end -%>
+<% if @resolve_retries -%>
   resolve_retries <%= @resolve_retries %>
+<% end -%>
+<% if @timeout -%>
 <% @timeout.each do |event, time| -%>
   timeout <%= event %> <%= time %>
 <% end -%>
+<% end -%>
+<% if @hold -%>
 <% @hold.each do |status, period| -%>
   hold <%= status %> <%= period %>
 <% end -%>
+<% end -%>
+<% if @accepted_payload_size -%>
   accepted_payload_size <%= @accepted_payload_size %>
+<% end -%>


### PR DESCRIPTION
This makes it so that `templates/haproxy_resolver_block.erb` only creates config entries for values that the user has specified. All other values can have defaults provided by HAProxy