### PR TITLE
Remove execute bit on systemd unit file

### DIFF
--- a/manifests/instance_service.pp
+++ b/manifests/instance_service.pp
@@ -101,7 +101,7 @@ define haproxy::instance_service (
       $unitfile = "/usr/lib/systemd/system/haproxy-${title}.service"
       file { $unitfile:
         ensure  => file,
-        mode    => '0744',
+        mode    => '0644',
         owner   => 'root',
         group   => 'root',
         content => template($haproxy_unit_template),


### PR DESCRIPTION
This change just switches the systemd unit file permissions from 0744 to 0644, as the execute bit for the owner can cause the warning to be logged `Configuration file <path-to-haproxy.service> is marked executable. Please remove executable permission bits. Proceeding anyway.`