### PR TITLE
Issue with accepted_payload_size

### DIFF
--- a/manifests/resolver.pp
+++ b/manifests/resolver.pp
@@ -122,11 +122,13 @@ define haproxy::resolver (
     $order = "25-${defaults}-${section_name}-02"
   }
 
-  # verify accepted_payload_size is withing the allowed range per HAProxy docs
+  # verify accepted_payload_size is withing the allowed range per HAProxy docs and only set if specified
   # https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.3.2-accepted_payload_size
-  if ($accepted_payload_size < 512) or ($accepted_payload_size > 8192) {
-    fail('$accepted_payload_size must be atleast 512 and not more than 8192')
-  }
+  if $accepted_payload_size != undef {
+    if ($accepted_payload_size < 512) or ($accepted_payload_size > 8192) {
+      fail('$accepted_payload_size must be atleast 512 and not more than 8192')
+    }
+  } 
 
   # Template uses: $section_name
   concat::fragment { "${instance_name}-${section_name}_resolver_block":

--- a/manifests/resolver.pp
+++ b/manifests/resolver.pp
@@ -128,7 +128,7 @@ define haproxy::resolver (
     if ($accepted_payload_size < 512) or ($accepted_payload_size > 8192) {
       fail('$accepted_payload_size must be atleast 512 and not more than 8192')
     }
-  } 
+  }
 
   # Template uses: $section_name
   concat::fragment { "${instance_name}-${section_name}_resolver_block":


### PR DESCRIPTION
Older HA-Proxies don't support accepted_payload_size in their config (I think pre 1.8) but do support the resolver, the current if statement requires an integer to be set.  Please include the following if so that if a value isn't set, the haproxy.cfg doesn't have accepted_payload_size added to it.  I've tested this in my local env.

  if $accepted_payload_size != undef {
    if ($accepted_payload_size < 512) or ($accepted_payload_size > 8192) {
      fail('$accepted_payload_size must be atleast 512 and not more than 8192')
    }
  } 

--- /etc/haproxy/haproxy.cfg    2019-02-11 13:30:21.274714771 +0100
+++ /tmp/puppet-file20190307-21421-7lv0x9       2019-03-07 14:26:06.562065732 +0100
@@ -67,6 +67,13 @@
   stats uri /haproxy?stats
   stats hide-version

+resolvers nl-rsg-aws
+  nameserver dns1 127.0.0.1:53
+  resolve_retries 30s
+  timeout retry 1s
+  hold nx 10
+  hold valid 30
+


Info: Computing checksum on file /etc/haproxy/haproxy.cfg

Thanks,
Dave