### PR TITLE
MODULES-9783 - Removed option tcplog

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -68,9 +68,6 @@ define haproxy::backend (
   $mode                    = undef,
   $collect_exported        = true,
   $options                 = {
-    'option'  => [
-      'tcplog',
-    ],
     'balance' => 'roundrobin',
   },
   $instance                = 'haproxy',

--- a/spec/defines/backend_spec.rb
+++ b/spec/defines/backend_spec.rb
@@ -17,7 +17,7 @@ describe 'haproxy::backend' do
       is_expected.to contain_concat__fragment('haproxy-bar_backend_block').with(
         'order'   => '20-bar-00',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nbackend bar\n  balance roundrobin\n  option tcplog\n",
+        'content' => "\nbackend bar\n  balance roundrobin\n",
       )
     }
   end


### PR DESCRIPTION
As of HA-Proxy 1.8, option tcplog directive is no longer supported for backends.