### PR TITLE
pdksync - Add support on Debian10

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {


### PR DESCRIPTION
Add support on Debian10
pdk version: `1.11.1` 
