### PR TITLE
(FM-8275) Add vagrant provision list

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -8,6 +8,9 @@ travis_deb:
 travis_el:
   provisioner: docker_exp
   images: ['waffleimage/centos7', 'waffleimage/oraclelinux7', 'waffleimage/scientificlinux7']
+vagrant:
+  provisioner: vagrant
+  images: ['centos/7', 'generic/ubuntu1804']
 release_checks:
   provisioner: vmpooler
   images: ['redhat-5-x86_64', 'redhat-7-x86_64', 'centos-5-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'oracle-5-x86_64', 'oracle-6-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64' ]


### PR DESCRIPTION
Prior to this commit the only provisioners included in
the provision lists were docker and vmpooler, neither
of which are particularly accessible to folks developing
on Windows outside of Puppet.

This commit adds a list which leverages the vagrant
provisioner.