### PR TITLE
(PDK-1501) Fix acceptance stages in Travis CI

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -24,6 +24,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
     -
       bundler_args:
       dist: trusty
@@ -38,6 +39,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
     -
       bundler_args:
       dist: trusty
@@ -51,6 +53,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
     -
       bundler_args:
       dist: trusty
@@ -64,6 +67,7 @@
       - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
+      stage: acceptance
 
 .rubocop.yml:
    default_configs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ matrix:
       rvm: 2.5.1
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[travis_deb]'", "bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='*'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
@@ -54,6 +55,7 @@ matrix:
       rvm: 2.5.1
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[travis_el]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
@@ -63,6 +65,7 @@ matrix:
       rvm: 2.5.1
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[travis_el]'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
@@ -72,6 +75,7 @@ matrix:
       rvm: 2.5.1
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
+      stage: acceptance
       sudo: required
 branches:
   only:


### PR DESCRIPTION
Previously the Travis CI file was brought under PDK control, however the
sync.yml did not contain the stage settings for the Litmus jobs which meant
that they did not run.  This commit fixes that error and runs PDK Update again