### PR TITLE
allow ipv6 bind

### DIFF
--- a/templates/fragments/_bind.erb
+++ b/templates/fragments/_bind.erb
@@ -20,7 +20,7 @@ else
   rescue ArgumentError => e
     valid_ip = false
   end
-  if ! valid_ip and ! String(virtual_ip).match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and virtual_ip != "*"
+  if ! valid_ip and ! String(virtual_ip).match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and virtual_ip != "*" and virtual_ip != "::"
     scope.function_fail(["Invalid IP address or hostname [#{virtual_ip}]"])
   end
   scope.function_fail(["Port [#{port}] is outside of range 1-65535"]) if port.to_i < 1 or port.to_i > 65535


### PR DESCRIPTION
```
frontend dex-frontend-ssl
  bind :::30554 v6only ssl crt /etc/haproxy/ssl/masterlb.pem
  mode tcp
  default_backend dex-backend
  option tcplog
```
Trying to add such config, i am getting the following error, because there is a strict virtual_ip validation under _bind.erb.

```Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function
Call, Failed to parse template haproxy/haproxy_frontend_block.erb:
  Filepath: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/functions/template.rb
  Line: 36
  Detail: Failed to parse template haproxy/fragments/_bind.erb:
  Filepath: /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/functions/fail.rb
  Line: 10
  Detail: Invalid IP address or hostname [::]
```

