### PR TITLE
Revert "(maint) Fix rubocop LineLength"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ AllCops:
   - "**/Puppetfile"
   - "**/Vagrantfile"
   - "**/Guardfile"
-Layout/LineLength:
+Metrics/LineLength:
   Description: People have wide screens, use them.
   Max: 200
 GetText:

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -125,7 +125,7 @@ describe 'haproxy::balancermember' do
       is_expected.to contain_concat__fragment('haproxy-croy_balancermember_tyler').with(
         'order'   => '20-croy-01-tyler',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "  server server01 192.168.56.200:18140 check\n  server server01 192.168.56.200:18150 check\n  server server02 192.168.56.201:18140 check\n  server server02 192.168.56.201:18150 check\n", # rubocop:disable Layout/LineLength
+        'content' => "  server server01 192.168.56.200:18140 check\n  server server01 192.168.56.200:18150 check\n  server server02 192.168.56.201:18140 check\n  server server02 192.168.56.201:18150 check\n", # rubocop:disable Metrics/LineLength
       )
     }
   end

--- a/spec/defines/frontend_spec.rb
+++ b/spec/defines/frontend_spec.rb
@@ -209,7 +209,7 @@ describe 'haproxy::frontend' do
       is_expected.to contain_concat__fragment('haproxy-apache_frontend_block').with(
         'order'   => '15-apache-00',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nfrontend apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  option tcplog\n", # rubocop:disable Layout/LineLength
+        'content' => "\nfrontend apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  option tcplog\n", # rubocop:disable Metrics/LineLength
       )
     }
   end
@@ -234,7 +234,7 @@ describe 'haproxy::frontend' do
       is_expected.to contain_concat__fragment('haproxy-apache_frontend_block').with(
         'order'   => '15-apache-00',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nfrontend apache\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind 8.252.206.99:80 \n  bind 8.252.206.100:80 \n  bind 8.252.206.101:80 \n  bind 10.1.3.21:80 \n  option tcplog\n", # rubocop:disable Layout/LineLength
+        'content' => "\nfrontend apache\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind 8.252.206.99:80 \n  bind 8.252.206.100:80 \n  bind 8.252.206.101:80 \n  bind 10.1.3.21:80 \n  option tcplog\n", # rubocop:disable Metrics/LineLength
       )
     }
   end
@@ -264,7 +264,7 @@ describe 'haproxy::frontend' do
       is_expected.to contain_concat__fragment('haproxy-apache_frontend_block').with(
         'order'   => '15-apache-00',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nfrontend apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  reqadd X-Forwarded-Proto:\\ https\n  default_backend dev00_webapp\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  bind-process all\n  compression algo gzip\n", # rubocop:disable Layout/LineLength
+        'content' => "\nfrontend apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  reqadd X-Forwarded-Proto:\\ https\n  default_backend dev00_webapp\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  bind-process all\n  compression algo gzip\n", # rubocop:disable Metrics/LineLength
       )
     }
   end

--- a/spec/defines/listen_spec.rb
+++ b/spec/defines/listen_spec.rb
@@ -279,7 +279,7 @@ describe 'haproxy::listen' do
       is_expected.to contain_concat__fragment('haproxy-apache_listen_block').with(
         'order'   => '20-apache-00',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nlisten apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  balance roundrobin\n  option tcplog\n", # rubocop:disable Layout/LineLength
+        'content' => "\nlisten apache\n  bind /var/run/ssl-frontend.sock user root mode 600 accept-proxy\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  balance roundrobin\n  option tcplog\n", # rubocop:disable Metrics/LineLength
       )
     }
   end
@@ -304,7 +304,7 @@ describe 'haproxy::listen' do
       is_expected.to contain_concat__fragment('haproxy-apache_listen_block').with(
         'order'   => '20-apache-00',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nlisten apache\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind 8.252.206.99:80 name input99\n  bind 8.252.206.100:80 name input100\n  bind 8.252.206.101:80 name input101\n  bind 10.1.3.21:80 name input21\n  balance roundrobin\n  option tcplog\n", # rubocop:disable Layout/LineLength
+        'content' => "\nlisten apache\n  bind :443,:8443 ssl crt public.puppetlabs.com no-sslv3\n  bind fd@${FD_APP1} \n  bind 1.1.1.1:80 \n  bind 2.2.2.2:8000-8010 ssl crt public.puppetlabs.com\n  bind 8.252.206.99:80 name input99\n  bind 8.252.206.100:80 name input100\n  bind 8.252.206.101:80 name input101\n  bind 10.1.3.21:80 name input21\n  balance roundrobin\n  option tcplog\n", # rubocop:disable Metrics/LineLength
       )
     }
   end
@@ -334,7 +334,7 @@ describe 'haproxy::listen' do
       is_expected.to contain_concat__fragment('haproxy-apache_listen_block').with(
         'order'   => '20-apache-00',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nlisten apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  reqadd X-Forwarded-Proto:\\ https\n  default_backend dev00_webapp\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  bind-process all\n  compression algo gzip\n", # rubocop:disable Layout/LineLength
+        'content' => "\nlisten apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  reqadd X-Forwarded-Proto:\\ https\n  default_backend dev00_webapp\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  bind-process all\n  compression algo gzip\n", # rubocop:disable Metrics/LineLength
       )
     }
   end
@@ -365,7 +365,7 @@ describe 'haproxy::listen' do
       is_expected.to contain_concat__fragment('haproxy-apache_listen_block').with(
         'order'   => '20-apache-00',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nlisten apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  bind-process all\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  compression algo gzip\n  default_backend dev00_webapp\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  reqadd X-Forwarded-Proto:\\ https\n  reqidel ^X-Forwarded-For:.*\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n", # rubocop:disable Layout/LineLength
+        'content' => "\nlisten apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  bind-process all\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  compression algo gzip\n  default_backend dev00_webapp\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  reqadd X-Forwarded-Proto:\\ https\n  reqidel ^X-Forwarded-For:.*\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n", # rubocop:disable Metrics/LineLength
       )
     }
   end
@@ -397,7 +397,7 @@ describe 'haproxy::listen' do
       is_expected.to contain_concat__fragment('haproxy-apache_listen_block').with(
         'order'   => '20-apache-00',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nlisten apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  bind-process all\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  compression algo gzip\n  default_backend dev00_webapp\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  reqidel ^X-Forwarded-For:.*\n  reqadd X-Forwarded-Proto:\\ https\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n", # rubocop:disable Layout/LineLength
+        'content' => "\nlisten apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  bind-process all\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  compression algo gzip\n  default_backend dev00_webapp\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  reqidel ^X-Forwarded-For:.*\n  reqadd X-Forwarded-Proto:\\ https\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n", # rubocop:disable Metrics/LineLength
       )
     }
   end

--- a/spec/defines/mapfile_spec.rb
+++ b/spec/defines/mapfile_spec.rb
@@ -33,7 +33,7 @@ describe 'haproxy::mapfile' do
       is_expected.to contain_file('haproxy_mapfile_domains-to-backends').with(
         'path'    => '/etc/haproxy/domains-to-backends.map',
         'ensure'  => 'present',
-        'content' => "# HAProxy map file \"domains-to-backends\"\n# Managed by Puppet\n\napp01.example.com bk_app01\napp02.example.com bk_app02\napp03.example.com bk_app03\napp04.example.com bk_app04\napp05.example.com bk_app05\napp06.example.com bk_app06\n", # rubocop:disable Layout/LineLength
+        'content' => "# HAProxy map file \"domains-to-backends\"\n# Managed by Puppet\n\napp01.example.com bk_app01\napp02.example.com bk_app02\napp03.example.com bk_app03\napp04.example.com bk_app04\napp05.example.com bk_app05\napp06.example.com bk_app06\n", # rubocop:disable Metrics/LineLength
       )
     }
   end

--- a/spec/defines/resolver_spec.rb
+++ b/spec/defines/resolver_spec.rb
@@ -26,7 +26,7 @@ describe 'haproxy::resolver' do
       is_expected.to contain_concat__fragment('haproxy-bar_resolver_block').with(
         'order'   => '20-bar-01',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nresolvers bar\n  nameserver dns1 1.1.1.1:53\n  nameserver dns2 1.1.1.2:53\n  resolve_retries 3\n  timeout retry 1s\n  hold other 30s\n  hold refused 30s\n  hold nx 30s\n  hold timeout 30s\n  hold valid 10s\n  accepted_payload_size 512\n", # rubocop:disable Layout/LineLength
+        'content' => "\nresolvers bar\n  nameserver dns1 1.1.1.1:53\n  nameserver dns2 1.1.1.2:53\n  resolve_retries 3\n  timeout retry 1s\n  hold other 30s\n  hold refused 30s\n  hold nx 30s\n  hold timeout 30s\n  hold valid 10s\n  accepted_payload_size 512\n", # rubocop:disable Metrics/LineLength
       )
     }
   end


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-haproxy#420


since its causing the following error on ruby 2.5.7 
Running RuboCop...
/home/travis/build/puppetlabs/puppetlabs-haproxy/.rubocop.yml: Layout/LineLength has the wrong namespace - should be Metrics
Inspecting 25 files

https://travis-ci.org/github/puppetlabs/puppetlabs-haproxy/jobs/670626556
