### PR TITLE
Add Oracle 6 back to release checks and run update yum-nss on this platform

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -19,4 +19,4 @@ travis_el7:
   images: ['litmusimage/centos:7', 'litmusimage/oraclelinux:7', 'litmusimage/scientificlinux:7']
 release_checks:
   provisioner: abs
-  images: [ 'redhat-7-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'centos-8-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'oracle-7-x86_64' ]
+  images: [ 'redhat-7-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'centos-8-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64' ]

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -55,6 +55,10 @@ RSpec.configure do |c|
         LitmusHelper.instance.run_shell("puppet apply -e 'include epel'")
       end
     end
+    if os[:family] == 'oracle' && os[:release].to_i == 6
+      LitmusHelper.instance.run_shell('yum clean all')
+      LitmusHelper.instance.run_shell('yum --disablerepo="epel" update nss -y')
+    end
     pp = <<-PP
     package { 'curl': ensure => present, }
     package { 'net-tools': ensure => present, }


### PR DESCRIPTION
I modified the spec_helper_acceptance_local.rb to update the yum-nss with the following code:
`if os[:family] == 'oracle' && os[:release].to_i == 6
LitmusHelper.instance.run_shell('yum clean all')
LitmusHelper.instance.run_shell('yum --disablerepo="epel" update nss -y')
end`
The problem was just with oracle-6-x86_64.