### PR TITLE
frontend options: order default_backend after specific backends to be able to use them

### DIFF
--- a/templates/fragments/_options.erb
+++ b/templates/fragments/_options.erb
@@ -23,6 +23,7 @@
       'reqadd' => 6,
       'redirect' => 7,
       'use_backend' => 8,
+      'default_backend' => 9,
       'use-server' => 9,
       'server' => 100,
     }


### PR DESCRIPTION
I need to specify some backends via use_backend. The default_backend option however ist sorted in front of the specified backends. 

