### PR TITLE
Fix incorrect options order in HAproxy 2.2.x

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -92,7 +92,17 @@ define haproxy::backend (
   }
 
   include haproxy::globals
-  $_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
+
+  # See https://github.com/puppetlabs/puppetlabs-haproxy/pull/442 - when using the option 'httpchk', it must be positioned
+  # before the 'http-check' directive in haproxy.cfg otherwise it will be ignored
+  if $options.is_hash and has_key($options, 'option') {
+    if ('httpchk' in $options['option']) {
+      warning('Overriding the value of $sort_options_alphabetic to "false" due to "httpchk" option defined')
+      $_sort_options_alphabetic = false
+    }
+  } else {
+    $_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
+  }
 
   if $defaults == undef {
     $order = "20-${section_name}-00"

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -75,6 +75,7 @@ describe 'configuring haproxy' do
           options   => { 'stats' => ['uri /','auth puppet:puppet'], },
         }
       PUPPETCODE
+
       it 'starts' do
         retry_on_error_matching do
           apply_manifest(pp_three, catch_failures: true)
@@ -86,6 +87,44 @@ describe 'configuring haproxy' do
           run_shell("/usr/bin/curl -u puppet:puppet localhost:#{port}") do |r|
             expect(r.stdout).to contain %r{HAProxy}
             expect(r.exit_code).to eq 0
+          end
+        end
+      end
+
+      context 'when "httpchk" option is defined and $sort_options_aphabetic => true' do
+        pp_httpchk_option = <<-PUPPETCODE
+        class { 'haproxy::globals':
+          sort_options_alphabetic => true,
+        }
+        class { 'haproxy': }
+        haproxy::listen { 'stats':
+          ipaddress => '127.0.0.1',
+          ports     => ['9091'],
+          mode      => 'http',
+        }
+        haproxy::backend { 'servers':
+          mode => 'http',
+          sort_options_alphabetic => true,
+          options => {
+            'option'  => [
+              'httpchk',
+            ],
+            'http-check' => 'disable-on-404',
+            'server' => [
+               'srv1 127.0.0.1:9091 check',
+            ],
+          },
+        }
+        PUPPETCODE
+
+        it 'overrides $sort_options_aphabetic to false and warn' do
+          apply_manifest(pp_httpchk_option, catch_failures: true) do |r|
+            expect(r.stderr).to contain %r{Overriding\sthe\svalue\sof\s\$sort_options_alphabetic\sto\s"false"\sdue\sto\s"httpchk"\soption\sdefined}
+          end
+        end
+        describe file('/etc/haproxy/haproxy.cfg') do
+          its(:content) do
+            is_expected.to match %r{backend\sservers\n\s+mode\shttp\n\s+option\shttpchk\n\s+http-check\s+disable-on-404}
           end
         end
       end

--- a/templates/fragments/_options.erb
+++ b/templates/fragments/_options.erb
@@ -24,6 +24,8 @@
       'redirect' => 7,
       'use_backend' => 8,
       'use-server' => 9,
+      'options' => 10,
+      'http-check' => 11,
       'server' => 100,
     }
   end


### PR DESCRIPTION
In the latest HAproxy version `option httpchk` must be located before `http-check` directive to allow L7 checks. Otherwise `httpchk` will be ignored. Source: https://www.haproxy.com/blog/announcing-haproxy-2-2/#health-check-overhaul

Sample config:
```
haproxy::backend { 'servers':
  mode => 'http',
  sort_options_alphabetic => false,
  options => {
    'option'  => [
      'httpchk',
    ],
    'http-check' => 'send meth HEAD uri /health ver HTTP/1.1 hdr Host test.local'
    'server' => [
       'srv1 192.168.1.5:80 check',
    ],
  },
}
```

The Result:

``` 
backend servers
   mode http
-  http-check send meth HEAD uri /health ver HTTP/1.1 hdr Host test.local
   option httpchk
+  http-check send meth HEAD uri /health ver HTTP/1.1 hdr Host test.local
   server srv1 192.168.1.5:80 check
```