### PR TITLE
Stop claiming support for RHEL5 and 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,8 +21,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
-        "6",
         "7",
         "8"
       ]


### PR DESCRIPTION
Since RHEL 6 requires an additional AddOn or subscription for haproxy
(https://access.redhat.com/solutions/319383) we cannot actually test
and support RHEL6. It still might work.