### PR TITLE
pdksync - Remove EL6 testing from Travis

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -27,9 +27,6 @@ travis_ub_6:
   - litmusimage/ubuntu:16.04
   - litmusimage/ubuntu:18.04
   - litmusimage/ubuntu:20.04
-travis_el6:
-  provisioner: docker_exp
-  images: []
 travis_el7:
   provisioner: docker_exp
   images:


### PR DESCRIPTION
Remove EL6 testing from Travis
pdk version: `1.18.1` 
