### PR TITLE
Fix 'option' entry name in option_order hash

### DIFF
--- a/spec/defines/listen_spec.rb
+++ b/spec/defines/listen_spec.rb
@@ -388,9 +388,10 @@ describe 'haproxy::listen' do
           'capture request header' => ['X-Forwarded-For len 50', 'Host len 15', 'Referrer len 15'],
           'acl'                    => ['dst_dev01 dst_port 48001', 'dst_dev02 dst_port 48002', 'dst_dev03 dst_port 48003'],
           'use_backend'            => ['dev01_webapp if dst_dev01', 'dev02_webapp if dst_dev02', 'dev03_webapp if dst_dev03'],
-          'option'                 => ['httplog', 'http-server-close', 'forwardfor except 127.0.0.1'],
+          'option'                 => ['httpchk', 'httplog', 'http-server-close', 'forwardfor except 127.0.0.1'],
           'compression'            => 'algo gzip',
           'bind-process'           => 'all',
+          'http-check'             => ['send hdr Host test.example.com meth GET uri /health', 'expect status 204'],
         },
       }
     end
@@ -399,7 +400,7 @@ describe 'haproxy::listen' do
       is_expected.to contain_concat__fragment('haproxy-apache_listen_block').with(
         'order'   => '20-apache-00',
         'target'  => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nlisten apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  bind-process all\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  compression algo gzip\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  reqidel ^X-Forwarded-For:.*\n  reqadd X-Forwarded-Proto:\\ https\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n  default_backend dev00_webapp\n", # rubocop:disable Layout/LineLength
+        'content' => "\nlisten apache\n  bind 0.0.0.0:48001-48003 \n  mode http\n  acl dst_dev01 dst_port 48001\n  acl dst_dev02 dst_port 48002\n  acl dst_dev03 dst_port 48003\n  bind-process all\n  capture request header X-Forwarded-For len 50\n  capture request header Host len 15\n  capture request header Referrer len 15\n  compression algo gzip\n  reqidel ^X-Forwarded-For:.*\n  reqadd X-Forwarded-Proto:\\ https\n  use_backend dev01_webapp if dst_dev01\n  use_backend dev02_webapp if dst_dev02\n  use_backend dev03_webapp if dst_dev03\n  default_backend dev00_webapp\n  option httpchk\n  option httplog\n  option http-server-close\n  option forwardfor except 127.0.0.1\n  http-check send hdr Host test.example.com meth GET uri /health\n  http-check expect status 204\n", # rubocop:disable Layout/LineLength
       )
     }
   end

--- a/templates/fragments/_options.erb
+++ b/templates/fragments/_options.erb
@@ -25,7 +25,7 @@
       'use_backend' => 8,
       'default_backend' => 9,
       'use-server' => 9,
-      'options' => 10,
+      'option' => 10,
       'http-check' => 11,
       'server' => 100,
     }


### PR DESCRIPTION
The `option_order` hash is used to determine the correct order of
various backend/listen configuration parameters but it contained
a misspelled "options" parameter that is really called "option". This
change fixes that and extends the spec tests for the haproxy::listen
define to catch this problem.

See the discussion in #442 for more details and the reasoning behind the
`option_order` hash and why option order is important in HAProxy.
Unfortunately the change in #442 also introduced the misspelled
parameter and no spec test caught it.