### PR TITLE
(IAC-1582) update the fact object value in spec tests

### DIFF
--- a/spec/unit/facter/haproxy_version_spec.rb
+++ b/spec/unit/facter/haproxy_version_spec.rb
@@ -23,7 +23,7 @@ describe Facter::Util::Fact do # rubocop:disable RSpec/FilePath
     it do
       allow(Facter::Util::Resolution).to receive(:exec)
       expect(Facter::Util::Resolution).to receive(:which).at_least(1).with('haproxy').and_return(false)
-      expect(Facter.fact(:haproxy_version)).to be_nil
+      expect(Facter.fact(:haproxy_version).value).to be_nil
     end
   end
 end


### PR DESCRIPTION
Request for a review
Spec tests are failing from the latest facter release 4.1.0
Previously calling Facter.fact with a non-existent fact would return nil and now it returns an object with an empty fact
