### PR TITLE
Fix haproxy_version fact for versions >= 2.4.0

### DIFF
--- a/lib/facter/haproxy_version.rb
+++ b/lib/facter/haproxy_version.rb
@@ -17,8 +17,9 @@ if defined?(Facter::Util::Resolution.which) && Facter::Util::Resolution.which('h
   Facter.add('haproxy_version') do
     haproxy_version_cmd = 'haproxy -v 2>&1'
     haproxy_version_result = Facter::Util::Resolution.exec(haproxy_version_cmd)
+    
     setcode do
-      haproxy_version_result.to_s.lines.first.strip.split(%r{HA-Proxy})[1].strip.split(%r{version})[1].strip.split(%r{((\d+\.){2,}\d+).*})[1]
+      haproxy_version_result.to_s.lines.first.strip.split(%r{HA?.Proxy})[1].strip.split(%r{version})[1].strip.split(%r{((\d+\.){2,}\d+).*})[1]
     end
   end
 end

--- a/lib/facter/haproxy_version.rb
+++ b/lib/facter/haproxy_version.rb
@@ -17,7 +17,6 @@ if defined?(Facter::Util::Resolution.which) && Facter::Util::Resolution.which('h
   Facter.add('haproxy_version') do
     haproxy_version_cmd = 'haproxy -v 2>&1'
     haproxy_version_result = Facter::Util::Resolution.exec(haproxy_version_cmd)
-    
     setcode do
       haproxy_version_result.to_s.lines.first.strip.split(%r{HA?.Proxy})[1].strip.split(%r{version})[1].strip.split(%r{((\d+\.){2,}\d+).*})[1]
     end


### PR DESCRIPTION
Starting version 2.4.0 `haproxy -v` output no longer print `HA-Proxy` instead print `HAProxy`.
Here's relevant commit for haproxy. https://github.com/haproxy/haproxy/commit/a5357cdfa55bae1bc7cf73dac628fe52c29f2337#diff-91a87d0577ca56659f3b8bc2814349b0462397368b4d966681564750a99cc786