### PR TITLE
Fix incompatibilities with haproxy 2.4

### DIFF
--- a/lib/facter/haproxy_version.rb
+++ b/lib/facter/haproxy_version.rb
@@ -15,7 +15,7 @@ if Facter::Util::Resolution.which('haproxy')
     haproxy_version_cmd = 'haproxy -v 2>&1'
     haproxy_version_result = Facter::Util::Resolution.exec(haproxy_version_cmd)
     setcode do
-      haproxy_version_result.to_s.lines.first.strip.split(/HA-Proxy/)[1].strip.split(/version/)[1].strip.split(/((\d+\.){2,}\d+).*/)[1]
+      haproxy_version_result.to_s.lines.first.strip.split(/HA-?Proxy/)[1].strip.split(/version/)[1].strip.split(/((\d+\.){2,}\d+).*/)[1]
     end
   end
 end

--- a/spec/unit/facter/haproxy_version_spec.rb
+++ b/spec/unit/facter/haproxy_version_spec.rb
@@ -17,6 +17,18 @@ describe Facter::Util::Fact do
     end
   end
 
+  context "haproxy 2.4 present" do
+    it do
+      haproxy_version_output = <<-EOS
+      HAProxy version 2.4.0-6cbbecf 2021/05/14 - https://haproxy.org/
+      Status: long-term supported branch - will stop receiving fixes around Q2 2026.
+      EOS
+      Facter::Util::Resolution.expects(:which).at_least(1).with("haproxy").returns(true)
+      Facter::Util::Resolution.expects(:exec).at_least(1).with("haproxy -v 2>&1").returns(haproxy_version_output)
+      Facter.fact(:haproxy_version).value.should == "2.4.0"
+    end
+  end
+
   context "haproxy not present" do
     it do
       Facter::Util::Resolution.stubs(:exec)


### PR DESCRIPTION
Haproxy 2.4 has changed output on `haproxy -v` that does not pass regex:
```
HAProxy version 2.4.0-6cbbecf 2021/05/14 - https://haproxy.org/
Status: long-term supported branch - will stop receiving fixes around Q2 2026.
Known bugs: http://www.haproxy.org/bugs/bugs-2.4.0.html
```