### PR TITLE
Adding chroot_dir_manage parameter.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,7 @@ define haproxy::config (
   $global_options,
   $defaults_options,
   $package_ensure,
+  $chroot_dir_manage,
   $config_dir = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   $custom_fragment = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   $merge_options = $haproxy::merge_options,
@@ -77,11 +78,13 @@ define haproxy::config (
     }
   }
 
-  if $_global_options['chroot'] {
-    file { $_global_options['chroot']:
-      ensure => directory,
-      owner  => $_global_options['user'],
-      group  => $_global_options['group'],
+  if $chroot_dir_manage {
+    if $_global_options['chroot'] {
+      file { $_global_options['chroot']:
+        ensure => directory,
+        owner  => $_global_options['user'],
+        group  => $_global_options['group'],
+      }
     }
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -216,6 +216,7 @@ define haproxy::instance (
     custom_fragment     => $custom_fragment,
     merge_options       => $merge_options,
     package_ensure      => $package_ensure,
+    chroot_dir_manage   => $chroot_dir_manage,
     config_validate_cmd => $config_validate_cmd,
   }
   haproxy::install { $title:

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -159,6 +159,7 @@ define haproxy::instance (
   String[1] $package_ensure                                    = 'present',
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure = 'running',
   Boolean $service_manage                                      = true,
+  Boolean $chroot_dir_manage                                   = true,
   Optional[String] $service_name                               = undef,
   Optional[Hash] $global_options                               = undef,
   Optional[Hash] $defaults_options                             = undef,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -27,6 +27,10 @@
 #   Chooses whether the haproxy service state should be managed by puppet at
 #   all. Defaults to true
 #
+# @param chroot_dir_manage
+#   Chooses whether the haproxy chroot directory should be managed by puppet
+#   at all. Defaults to true
+#
 # @param service_name
 #   The service name for haproxy. Defaults to undef. If no name is given then
 #   the value computed for $instance_name will be used.

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -222,6 +222,20 @@ describe 'haproxy::instance' do
             end
           end
         end
+        context "when on #{osfamily} family operatingsystems without managing the chroot directory" do
+          let(:facts) do
+            { osfamily: osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'chroot_dir_manage' => false,
+            }
+          end
+
+          it 'does not manage the haproxy chroot directory' do
+            subject.should_not contain_file('/var/lib/haproxy')
+          end
+        end
         context "on #{osfamily} when specifying a restart_command" do
           let(:facts) do
             { osfamily: osfamily }.merge default_facts


### PR DESCRIPTION
This PR adds a `chroot_dir_manage` parameter to the `haproxy::instance` and `haproxy::config` defined types.

I added it because the default permissions for the chroot directory on RHEL is owned by root. Changing it to the 'haproxy' user causes SELinux problems. I prefer leaving the directory owned by root.