### PR TITLE
Adding chroot_dir_manage parameter.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,7 @@ define haproxy::config (
   $global_options,
   $defaults_options,
   $package_ensure,
+  $chroot_dir_manage,
   $config_dir = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   $custom_fragment = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   $merge_options = $haproxy::merge_options,
@@ -77,11 +78,13 @@ define haproxy::config (
     }
   }
 
-  if $_global_options['chroot'] {
-    file { $_global_options['chroot']:
-      ensure => directory,
-      owner  => $_global_options['user'],
-      group  => $_global_options['group'],
+  if $chroot_dir_manage {
+    if $_global_options['chroot'] {
+      file { $_global_options['chroot']:
+        ensure => directory,
+        owner  => $_global_options['user'],
+        group  => $_global_options['group'],
+      }
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,10 @@
 # @param service_options
 #   Contents for the `/etc/defaults/haproxy` file on Debian. Defaults to "ENABLED=1\n" on Debian, and is ignored on other systems.
 #
+# @param chroot_dir_manage
+#   Chooses whether the haproxy chroot directory should be managed by puppet
+#   at all. Defaults to true
+#
 # @param sysconfig_options
 #   Contents for the `/etc/sysconfig/haproxy` file on RedHat(-based) systems.
 #   Defaults to OPTIONS="" on RedHat(-based) systems and is ignored on others
@@ -120,6 +124,7 @@ class haproxy (
   String $package_name                                         = $haproxy::params::package_name,
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure = 'running',
   Boolean $service_manage                                      = true,
+  Boolean $chroot_dir_manage                                   = true,
   String $service_name                                         = $haproxy::params::service_name,
   String $service_options                                      = $haproxy::params::service_options,
   $sysconfig_options                                           = $haproxy::params::sysconfig_options,
@@ -172,6 +177,7 @@ class haproxy (
     service_ensure      => $_service_ensure,
     service_manage      => $_service_manage,
     service_name        => $service_name,
+    chroot_dir_manage   => $chroot_dir_manage,
     global_options      => $global_options,
     defaults_options    => $defaults_options,
     restart_command     => $restart_command,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -27,6 +27,10 @@
 #   Chooses whether the haproxy service state should be managed by puppet at
 #   all. Defaults to true
 #
+# @param chroot_dir_manage
+#   Chooses whether the haproxy chroot directory should be managed by puppet
+#   at all. Defaults to true
+#
 # @param service_name
 #   The service name for haproxy. Defaults to undef. If no name is given then
 #   the value computed for $instance_name will be used.
@@ -159,6 +163,7 @@ define haproxy::instance (
   String[1] $package_ensure                                    = 'present',
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure = 'running',
   Boolean $service_manage                                      = true,
+  Boolean $chroot_dir_manage                                   = true,
   Optional[String] $service_name                               = undef,
   Optional[Hash] $global_options                               = undef,
   Optional[Hash] $defaults_options                             = undef,
@@ -215,6 +220,7 @@ define haproxy::instance (
     custom_fragment     => $custom_fragment,
     merge_options       => $merge_options,
     package_ensure      => $package_ensure,
+    chroot_dir_manage   => $chroot_dir_manage,
     config_validate_cmd => $config_validate_cmd,
   }
   haproxy::install { $title:

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -222,6 +222,20 @@ describe 'haproxy::instance' do
             end
           end
         end
+        context "when on #{osfamily} family operatingsystems without managing the chroot directory" do
+          let(:facts) do
+            { osfamily: osfamily }.merge default_facts
+          end
+          let(:params) do
+            {
+              'chroot_dir_manage' => false,
+            }
+          end
+
+          it 'does not manage the haproxy chroot directory' do
+            subject.should_not contain_file('/var/lib/haproxy')
+          end
+        end
         context "on #{osfamily} when specifying a restart_command" do
           let(:facts) do
             { osfamily: osfamily }.merge default_facts


### PR DESCRIPTION
This PR adds a chroot_dir_manage parameter to the haproxy::instance and haproxy::config defined types.

I added it because the default permissions for the chroot directory on RHEL is owned by root. Changing it to the 'haproxy' user causes SELinux problems. I prefer leaving the directory owned by root.