### PR TITLE
HAPROXY: Version 2.3.x supports Syslog Protocol (UDP/TCP)

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -46,8 +46,14 @@ jobs:
       run: |
         echo "::set-output name=ver::$(jq --raw-output .version metadata.json)"
 
-    - name: "Commit changes"
+    - name: "Check if a release is necessary"
       if: ${{ github.repository_owner == 'puppetlabs' }}
+      id: check
+      run: |
+        git diff --quiet CHANGELOG.md && echo "::set-output name=release::false" || echo "::set-output name=release::true"
+
+    - name: "Commit changes"
+      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
       run: |
         git config --local user.email "${{ github.repository_owner }}@users.noreply.github.com"
         git config --local user.name "GitHub Action"
@@ -57,7 +63,7 @@ jobs:
     - name: Create Pull Request
       id: cpr
       uses: puppetlabs/peter-evans-create-pull-request@v3
-      if: ${{ github.repository_owner == 'puppetlabs' }}
+      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "Release prep v${{ steps.gv.outputs.ver }}"
@@ -73,7 +79,7 @@ jobs:
         labels: "maintenance"
 
     - name: PR outputs
-      if: ${{ github.repository_owner == 'puppetlabs' }}
+      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
       run: |
         echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
         echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+
 env:
   HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
   HONEYCOMB_DATASET: litmus tests

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -2,6 +2,7 @@ name: "PR Testing"
 
 on: [pull_request]
 
+
 env:
   HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
   HONEYCOMB_DATASET: litmus tests
@@ -50,6 +51,11 @@ jobs:
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
         echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+    - name: Run validation steps
+      run: |
+        bundle exec rake validate
+      if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Setup Acceptance Test Matrix
       id: get-matrix

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
   pull_request:
 
+
 env:
   HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
   HONEYCOMB_DATASET: litmus tests
@@ -54,6 +55,11 @@ jobs:
           buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
           echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
           echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+      - name: Run Static & Syntax Tests
+        if: ${{ github.repository_owner == 'puppetlabs' }}
+        run: |
+          buildevents cmd $TRACE_ID $STEP_ID 'static_syntax_checks' -- bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
 
       - name: Setup Spec Test Matrix
         id: get-matrix
@@ -120,10 +126,6 @@ jobs:
           buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
           echo ::endgroup::
 
-      - name: Run Static & Syntax Tests
-        run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'static_syntax_checks Puppet ${{ matrix.puppet_version }}, Ruby ${{ matrix.ruby_version }}' -- bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
-      
       - name: Run parallel_spec tests
         run: |
           buildevents cmd $TRACE_ID $STEP_ID 'rake parallel_spec Puppet ${{ matrix.puppet_version }}, Ruby ${{ matrix.ruby_version }}' -- bundle exec rake parallel_spec

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?

--- a/lib/facter/find_ip.rb
+++ b/lib/facter/find_ip.rb
@@ -1,0 +1,10 @@
+Puppet::Functions.create_function(:find_ip) do
+    def find_ip(hostname)
+        the_ip = nil
+        begin
+            the_ip = IPSocket.getaddress(hostname)
+        rescue SocketError
+        end
+        return the_ip
+    end
+end

--- a/lib/facter/find_ip.rb
+++ b/lib/facter/find_ip.rb
@@ -1,10 +1,11 @@
 Puppet::Functions.create_function(:find_ip) do
-    def find_ip(hostname)
-        the_ip = nil
-        begin
-            the_ip = IPSocket.getaddress(hostname)
-        rescue SocketError
-        end
-        return the_ip
+  def find_ip(hostname)
+    the_ip = nil
+    begin
+      the_ip = IPSocket.getaddress(hostname)
+    rescue SocketError
+      puts 'SocketError'
     end
+    the_ip
+  end
 end

--- a/manifests/logforward.pp
+++ b/manifests/logforward.pp
@@ -1,0 +1,137 @@
+# @summary
+#   This type will setup a Log forwarding service configuration block inside
+#   the haproxy.cfg file on an haproxy load balancer.
+#
+# @note
+#   Currently requires the puppetlabs/concat module on the Puppet Forge and
+#   uses storeconfigs on the Puppet Server to export/collect resources
+#   from all balancer members.
+#
+# @param section_name
+#    This name goes right after the 'log-forward' statement in haproxy.cfg
+#    Default: $name (the namevar of the resource).
+#
+# @param options
+#   A hash of options that are inserted into the frontend service
+#    configuration block.
+#
+# @param sort_options_alphabetic
+#   Sort options either alphabetic or custom like haproxy internal sorts them.
+#   Defaults to true.
+#
+# @param defaults
+#   Name of the defaults section this backend will use.
+#   Defaults to undef which means the global defaults section will be used.
+#
+# @param bind
+#   Set of ip addresses, port and bind options
+#   $bind = { '10.0.0.1:80' => ['ssl', 'crt', '/path/to/my/crt.pem'] }
+#
+# @param ipaddress
+#   The ip address the proxy binds to.
+#    Empty addresses, '*', and '0.0.0.0' mean that the proxy listens
+#    to all valid addresses on the system.
+#
+# @param collect_exported
+#   Boolean, default 'true'. True means 'collect exported @@balancermember resources'
+#    (for the case when every balancermember node exports itself), false means
+#    'rely on the existing declared balancermember resources' (for the case when you
+#    know the full set of balancermembers in advance and use haproxy::balancermember
+#    with array arguments, which allows you to deploy everything in 1 run)
+#
+# @param configure_ring_buffer
+#   Boolean, default 'true'. True means 'Creates a new ring-buffer'
+#
+# @example
+#  Exporting the resource for a balancer member:
+#
+#  haproxy::logforward { 'puppet00':
+#    ipaddress    => $::ipaddress,
+#    ports        => '514',
+#    options      => {
+#     'log'                                    => [
+#       'global',
+#     ]
+#      'log' => 'log01.local:514 format rfc5424 sample 1:2 local7 info',
+#    },
+#    ring_options => {
+#     'format'                                 => [
+#       'rfc5424',
+#     ]
+#    },
+#
+# === Authors
+#
+# Erwin Dwight S. Paler <erwin.dwight.paler@gmail.com>
+#
+define haproxy::logforward (
+  $ports                                       = undef,
+  $ipaddress                                   = undef,
+  Optional[Hash] $dgram_bind                   = undef,
+  Optional[Hash] $bind                         = undef,
+  $options                                     = {
+    'log'                                      => [
+      'global',
+    ],
+  },
+  $ring_options                                = {
+    'format'                                   => [
+      'rfc5424',
+    ],
+  },
+  $collect_exported                            = true,
+  $configure_ring_buffer                       = true,
+  $instance                                    = 'haproxy',
+  $section_name                                = $name,
+  Optional[Stdlib::Absolutepath] $config_file  = undef,
+) {
+  if $ports and $bind {
+    fail('The use of $ports and $bind is mutually exclusive, please choose either one')
+  }
+  if $ipaddress and $bind {
+    fail('The use of $ipaddress and $bind is mutually exclusive, please choose either one')
+  }
+
+  include ::haproxy::params
+
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $_config_file = pick($config_file, $haproxy::config_file)
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $_config_file = pick($config_file, inline_template($haproxy::params::config_file_tmpl))
+  }
+
+  include haproxy::globals
+  $_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
+
+  if $defaults == undef {
+    $order = "15-${section_name}-00"
+  } else {
+    if $defaults_use_backend and has_key($options, 'default_backend') {
+      $order = "25-${defaults}-${options['default_backend']}-00-${section_name}"
+    } else {
+      $order = "25-${defaults}-${section_name}-00"
+    }
+  }
+  # Template uses: $section_name, $ipaddress, $ports, $options
+  concat::fragment { "${instance_name}-${section_name}_log-forward_block":
+    order   => $order,
+    target  => $_config_file,
+    content => template('haproxy/haproxy_log-forward_block.erb'),
+  }
+
+  if $configure_ring_buffer {
+    concat::fragment { "${instance_name}-${section_name}_log-forward-ring":
+      order   => $order,
+      target  => $_config_file,
+      content => template('haproxy/haproxy_ring_block.erb'),
+    }
+  }
+
+  if $collect_exported {
+    haproxy::balancermember::collect_exported { $section_name: }
+  }
+  # else: the resources have been created and they introduced their
+  # concat fragments. We don't have to do anything about them.
+}

--- a/manifests/logforward.pp
+++ b/manifests/logforward.pp
@@ -39,26 +39,16 @@
 #    know the full set of balancermembers in advance and use haproxy::balancermember
 #    with array arguments, which allows you to deploy everything in 1 run)
 #
-# @param configure_ring_buffer
-#   Boolean, default 'true'. True means 'Creates a new ring-buffer'
-#
-# @example
-#  Exporting the resource for a balancer member:
-#
 #  haproxy::logforward { 'puppet00':
 #    ipaddress    => $::ipaddress,
 #    ports        => '514',
 #    options      => {
-#     'log'                                    => [
-#       'global',
-#     ]
-#      'log' => 'log01.local:514 format rfc5424 sample 1:2 local7 info',
+#      'log'                                    => [
+#        'global',
+#      ]
+#        'log' => 'log01.local:514 format rfc5424 sample 1:2 local7 info',
 #    },
-#    ring_options => {
-#     'format'                                 => [
-#       'rfc5424',
-#     ]
-#    },
+#  }
 #
 # === Authors
 #
@@ -74,13 +64,7 @@ define haproxy::logforward (
       'global',
     ],
   },
-  $ring_options                                = {
-    'format'                                   => [
-      'rfc5424',
-    ],
-  },
   $collect_exported                            = true,
-  $configure_ring_buffer                       = true,
   $instance                                    = 'haproxy',
   $section_name                                = $name,
   Optional[Stdlib::Absolutepath] $config_file  = undef,
@@ -119,14 +103,6 @@ define haproxy::logforward (
     order   => $order,
     target  => $_config_file,
     content => template('haproxy/haproxy_log-forward_block.erb'),
-  }
-
-  if $configure_ring_buffer {
-    concat::fragment { "${instance_name}-${section_name}_log-forward-ring":
-      order   => $order,
-      target  => $_config_file,
-      content => template('haproxy/haproxy_ring_block.erb'),
-    }
   }
 
   if $collect_exported {

--- a/manifests/logforward/configure.pp
+++ b/manifests/logforward/configure.pp
@@ -2,7 +2,7 @@
 #   Hiera support to setup a Log forwarding service configuration block inside
 #   the haproxy.cfg file on an haproxy load balancer.
 #
-# @param logforward
+# @param instance
 #   Hash [param*]
 #
 # @example

--- a/manifests/logforward/configure.pp
+++ b/manifests/logforward/configure.pp
@@ -1,0 +1,37 @@
+# @summary
+#   Hiera support to setup a Log forwarding service configuration block inside
+#   the haproxy.cfg file on an haproxy load balancer.
+#
+# @param logforward
+#   Hash [param*]
+#
+# @example
+#  Exporting the resource for a balancer member:
+#
+# === Authors
+#
+# Erwin Dwight S. Paler <erwin.dwight.paler@gmail.com>
+#
+class haproxy::logforward::configure (
+  Hash $instance = {},
+) {
+
+  include ::haproxy
+
+  $instance.each |$name, $params| {
+    $ipaddress = $params['address'] ? {
+      Stdlib::IP::Address => $params['address'],
+      undef       => undef,
+      default     => find_ip($params['address']),
+    }
+    haproxy::logforward {
+      $name:
+        * => $params,
+        ;
+      default:
+        ipaddress => $ipaddress,
+        ;
+    }
+
+  }
+}

--- a/manifests/ring.pp
+++ b/manifests/ring.pp
@@ -1,0 +1,76 @@
+# @summary
+#   This type will create a ring-buffer configuration block inside
+#   the haproxy.cfg file on an haproxy load balancer.
+#
+# @note
+#   Currently requires the puppetlabs/concat module on the Puppet Forge and
+#   uses storeconfigs on the Puppet Server to export/collect resources
+#   from all balancer members.
+#
+# @param section_name
+#    This name goes right after the 'ring' statement in haproxy.cfg
+#    Default: $name (the namevar of the resource).
+#
+# @param options
+#   A hash of options that are inserted into the frontend service
+#    configuration block.
+#
+# @param sort_options_alphabetic
+#   Sort options either alphabetic or custom like haproxy internal sorts them.
+#   Defaults to true.
+#
+# @param defaults
+#   Name of the defaults section this backend will use.
+#   Defaults to undef which means the global defaults section will be used.
+#
+#  haproxy::ring { 'puppet00':
+#    ring_options => {
+#     'log'                                    => [
+#       'global',
+#     ]
+#     'server'    => 'log01.local 127.0.0.1:1510 log-proto octet-count',
+#    },
+#
+# === Authors
+#
+# Erwin Dwight S. Paler <erwin.dwight.paler@gmail.com>
+#
+define haproxy::ring (
+  $ring_options                                = {
+    'description'                              => [
+      'My local buffer',
+    ],
+  },
+  $instance                                    = 'haproxy',
+  $section_name                                = $name,
+  Optional[Stdlib::Absolutepath] $config_file  = undef,
+) {
+
+  include ::haproxy::params
+
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $_config_file = pick($config_file, $haproxy::config_file)
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $_config_file = pick($config_file, inline_template($haproxy::params::config_file_tmpl))
+  }
+
+  include haproxy::globals
+  $_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
+
+  if $defaults == undef {
+    $order = "15-${section_name}-00"
+  } else {
+    if $defaults_use_backend and has_key($options, 'default_backend') {
+      $order = "25-${defaults}-${options['default_backend']}-00-${section_name}"
+    } else {
+      $order = "25-${defaults}-${section_name}-00"
+    }
+  }
+  concat::fragment { "${instance_name}-${section_name}_log-forward-ring":
+    order   => $order,
+    target  => $_config_file,
+    content => template('haproxy/haproxy_ring_block.erb'),
+  }
+}

--- a/manifests/ring/configure.pp
+++ b/manifests/ring/configure.pp
@@ -1,0 +1,22 @@
+#
+# @param instance
+#   Hash [param*]
+#
+# === Authors
+#
+# Erwin Dwight S. Paler <erwin.dwight.paler@gmail.com>
+#
+class haproxy::ring::configure (
+  Hash $instance = {},
+) {
+
+  include ::haproxy
+
+  $instance.each |$name, $params| {
+    haproxy::ring {
+      $name:
+        * => $params,
+        ;
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -73,6 +73,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "heads/main-0-g03daa92",
-  "pdk-version": "2.1.0"
+  "template-ref": "heads/main-0-gce1ad46",
+  "pdk-version": "2.2.0"
 }

--- a/templates/fragments/_dgram-bind.erb
+++ b/templates/fragments/_dgram-bind.erb
@@ -1,0 +1,31 @@
+<%
+require 'ipaddr'
+if @dgram_bind
+  @dgram_bind.sort_by { |address_port, dgram_bind_params|
+    md = /^((\d+)\.(\d+)\.(\d+)\.(\d+))?(.*)/.match(address_port)
+    [ (md[1] ? md[2..5].inject(0){ |addr, octet| (addr << 8) + octet.to_i } : -1), md[6] ]
+
+  }.map do |address_port, dgram_bind_params|
+-%>  dgram-bind <%= address_port -%> <%= Array(dgram_bind_params).join(" ") %>
+<%
+
+  end
+else
+-%>
+<%-
+  Array(@ipaddress).uniq.each do |virtual_ip| (@ports.is_a?(Array) ? @ports : Array(@ports.split(","))).each do |port|
+  begin
+    IPAddr.new(virtual_ip)
+    valid_ip = true
+  rescue ArgumentError => e
+    valid_ip = false
+  end
+  if ! valid_ip and ! String(virtual_ip).match(/^[A-Za-z][A-Za-z0-9\.-]+$/) and virtual_ip != "*" and virtual_ip != "::"
+    scope.function_fail(["Invalid IP address or hostname [#{virtual_ip}]"])
+  end
+  scope.function_fail(["Port [#{port}] is outside of range 1-65535"]) if port.to_i < 1 or port.to_i > 65535
+-%>
+  dgram-bind <%= virtual_ip -%>:<%= port -%>
+<%- end -%>
+<%- end -%>
+<%- end -%>

--- a/templates/fragments/_ring_options.erb
+++ b/templates/fragments/_ring_options.erb
@@ -1,0 +1,40 @@
+<%-
+  # non mentioned option have a value of 0
+  # lower values come first
+  if @_sort_options_alphabetic == true
+    option_order = {}
+  else
+    option_order = {
+      'description' => -1,
+      'format' => 2,
+      'maxlen' => 3,
+      'size' => 4,
+      'option' => 5,
+      'server' => 100,
+    }
+  end
+-%>
+<% if @ring_options.is_a?(Hash) -%>
+<%# ruby sorts arrays like strings: the first elements are compared, if they -%>
+<%# are equal the next elements are compared and so on. The following sort -%>
+<%# provides a two element array, the first element a classification of the -%>
+<%# option with a default value of 0 if the option is not found in the -%>
+<%# option_order hash and the second element the option itself. -%>
+<% @ring_options.sort{|a,b| [option_order.fetch(a[0],0), a[0]] <=> [option_order.fetch(b[0],0), b[0]] }.each do |key, val| -%>
+<% Array(val).reject{|v| v == :undef }.each do |item| -%>
+  <%= key %> <%= item %>
+<% end -%>
+<% end -%>
+<% elsif @ring_options.is_a?(Array) -%>
+<%# Iterate over array elements; each element is a hash (containing key-value -%>
+<%# pairs); in case a hash contains more than one key-value pair the hash is -%>
+<%# sorted by key name before outputting the key name (= option name) and its -%>
+<%# value (or values, one per line) -%>
+<% @ring_options.each do |option| -%>
+<% option.sort{|a,b| [option_order.fetch(a[0],0), a[0]] <=> [option_order.fetch(b[0],0), b[0]] }.map do |key, val| -%>
+<% Array(val).reject{|v| v == :undef }.each do |item| -%>
+  <%= key %> <%= item %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% end -%>

--- a/templates/fragments/_ring_options.erb
+++ b/templates/fragments/_ring_options.erb
@@ -9,7 +9,8 @@
       'format' => 2,
       'maxlen' => 3,
       'size' => 4,
-      'option' => 5,
+      'timeout connect' => 5,
+      'timeout server' => 6,
       'server' => 100,
     }
   end

--- a/templates/haproxy_log-forward_block.erb
+++ b/templates/haproxy_log-forward_block.erb
@@ -1,0 +1,5 @@
+
+log-forward <%= @section_name %>
+<%= scope.function_template(['haproxy/fragments/_dgram-bind.erb']) -%>
+<%= scope.function_template(['haproxy/fragments/_bind.erb']) -%>
+<%= scope.function_template(['haproxy/fragments/_options.erb']) -%>

--- a/templates/haproxy_ring_block.erb
+++ b/templates/haproxy_ring_block.erb
@@ -1,0 +1,3 @@
+
+ring <%= @section_name %>
+<%= scope.function_template(['haproxy/fragments/_ring_options.erb']) -%>


### PR DESCRIPTION
We have a use case to migrate our central Syslog servers to be behind haproxy, and we need TCP and UDP backend, so haproxy version 2.3 will help us with our use case.

https://www.haproxy.com/blog/announcing-haproxy-2-3/#syslog-protocol-udp-tcp
https://cbonte.github.io/haproxy-dconv/2.3/configuration.html#3.10