### PR TITLE
Fix refresh on file and refresh on service/sysconfig change

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,9 +50,10 @@ define haproxy::config (
     file { $_config_file: ensure => absent }
   } else {
     concat { $_config_file:
-      owner => '0',
-      group => '0',
-      mode  => '0640',
+      owner  => '0',
+      group  => '0',
+      mode   => '0640',
+      notify => Service[$instance_name],
     }
 
     # validate_cmd introduced in Puppet 3.5

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -238,7 +238,7 @@ define haproxy::instance (
 
   if $package_ensure == 'absent' or $package_ensure == 'purged' {
     anchor { "${title}::haproxy::begin": }
-    ~> Haproxy::Service[$title]
+    -> Haproxy::Service[$title]
     -> Haproxy::Config[$title]
     -> Haproxy::Install[$title]
     -> anchor { "${title}::haproxy::end": }
@@ -246,7 +246,7 @@ define haproxy::instance (
     anchor { "${title}::haproxy::begin": }
     -> Haproxy::Install[$title]
     -> Haproxy::Config[$title]
-    ~> Haproxy::Service[$title]
+    -> Haproxy::Service[$title]
     -> anchor { "${title}::haproxy::end": }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,13 +19,13 @@ define haproxy::service (
     if ($::osfamily == 'Debian') {
       file { "/etc/default/${instance_name}":
         content => $service_options,
-        before  => Service[$instance_name],
+        notify  => Service[$instance_name],
       }
     }
     if ($::osfamily == 'Redhat') {
       file {"/etc/sysconfig/${instance_name}":
         content => $sysconfig_options,
-        before  => Service[$instance_name],
+        notify  => Service[$instance_name],
       }
     }
 


### PR DESCRIPTION
Fix error on install or change on `/etc/haproxy/haproxy.cfg` : 
```
Info: Haproxy::Config[haproxy]: Scheduling refresh of Haproxy::Service[haproxy]
Info: Haproxy::Service[haproxy]: Scheduling refresh of File[/etc/sysconfig/haproxy]
Info: Haproxy::Service[haproxy]: Scheduling refresh of Service[haproxy]
Error: /Stage[main]/Haproxy/Haproxy::Instance[haproxy]/Haproxy::Service[haproxy]/File[/etc/sysconfig/haproxy]: Failed to call refresh: undefined local variable or method `provider' for File[/etc/sysconfig/haproxy](provider=posix):Puppet::Type::File::ProviderPosix
Error: /Stage[main]/Haproxy/Haproxy::Instance[haproxy]/Haproxy::Service[haproxy]/File[/etc/sysconfig/haproxy]: undefined local variable or method `provider' for File[/etc/sysconfig/haproxy](provider=posix):Puppet::Type::File::ProviderPosix
```
Fix Service haproxy not refresh when /etc/sysconfig/haproxy is modified.

OS : RockyLinux 8.4
Server :
[puppet-agent-7.11.0-1.el8.x86_64
puppetserver-7.4.0-1.el8.noarch
puppetdb-termini-7.6.0-1.el8.noarch
puppetdb-7.6.0-1.el8.noarch
Client :
puppet-agent-7.11.0-1.el8.x86_64