### PR TITLE
haproxy_userlist: fix empty users/groups handling.

### DIFF
--- a/templates/haproxy_userlist_block.epp
+++ b/templates/haproxy_userlist_block.epp
@@ -1,7 +1,7 @@
 <%- |
-  Optional[Array[Variant[String, Sensitive[String]]]] $epp_users,
-  Optional[Array[String]]                             $epp_groups,
-  String                                              $epp_section_name,
+  Array[Variant[String, Sensitive[String]]] $epp_users = [],
+  Array[String]                             $epp_groups = [],
+  String                                    $epp_section_name,
 | -%>
 
 userlist <%= $epp_section_name %>


### PR DESCRIPTION
Fixing https://tickets.puppetlabs.com/browse/MODULES-11215
haproxy : inconsistent $groups handling for userlist groups

$epp_groups and $epp_users are not optional in the template code,
default them to [].