### PR TITLE
pdksync - (GH-cat-12) Add Support for Redhat 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,8 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -42,7 +42,11 @@ RSpec.configure do |c|
     LitmusHelper.instance.run_shell('setenforce 0', expect_failures: true) if os[:family].match?(%r{redhat|oracle})
 
     if os[:family] == 'redhat' && os[:release].to_i != 8
-      LitmusHelper.instance.run_shell('puppet module install stahnma/epel')
+      epel_owner = 'puppet'
+      if os[:release].to_i == 6
+        epel_owner = 'stahnma'
+      end
+      LitmusHelper.instance.run_shell("puppet module install #{epel_owner}/epel")
       if os[:release][0].match?(%r{5|6})
         pp = <<-PP
         class { 'epel':


### PR DESCRIPTION
(GH-cat-12) Add Support for Redhat 9
pdk version: `2.4.0` 
