### PR TITLE
Fix condition error with accepted_payload_size

### DIFF
--- a/manifests/resolver.pp
+++ b/manifests/resolver.pp
@@ -122,8 +122,10 @@ define haproxy::resolver (
 
   # verify accepted_payload_size is withing the allowed range per HAProxy docs
   # https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.3.2-accepted_payload_size
-  if ($accepted_payload_size < 512) or ($accepted_payload_size > 8192) {
-    fail('$accepted_payload_size must be atleast 512 and not more than 8192')
+  if $accepted_payload_size != undef {
+    if ($accepted_payload_size < 512) or ($accepted_payload_size > 8192) {
+      fail('$accepted_payload_size must be atleast 512 and not more than 8192')
+    }
   }
 
   # Template uses: $section_name


### PR DESCRIPTION
The integer comparison will fail when accepted_payload_size is undef.

```
Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Comparison of: Undef Value < Integer, is not possible. Caused by 'Only Strings, Numbers, Timespans, Timestamps, and Versions are comparable'. (file: /puppet/modules/haproxy/manifests/resolver.pp, line: 125, column: 30)
```