### PR TITLE
update resolver parameters

### DIFF
--- a/manifests/resolver.pp
+++ b/manifests/resolver.pp
@@ -91,7 +91,8 @@ define haproxy::resolver (
   $hold                    = undef,
   $resolve_retries         = undef,
   $timeout                 = undef,
-  $accepted_payload_size   = undef,
+  # https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.3.2-accepted_payload_size
+  Optional[Integer[512, 8192]] $accepted_payload_size = undef,
   $instance                = 'haproxy',
   $section_name            = $name,
   $sort_options_alphabetic = undef,
@@ -118,12 +119,6 @@ define haproxy::resolver (
     $order = "20-${section_name}-01"
   } else {
     $order = "25-${defaults}-${section_name}-02"
-  }
-
-  # verify accepted_payload_size is withing the allowed range per HAProxy docs
-  # https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.3.2-accepted_payload_size
-  if ($accepted_payload_size < 512) or ($accepted_payload_size > 8192) {
-    fail('$accepted_payload_size must be atleast 512 and not more than 8192')
   }
 
   # Template uses: $section_name

--- a/manifests/resolver.pp
+++ b/manifests/resolver.pp
@@ -15,6 +15,15 @@
 # @param nameservers
 #   Set of id, ip addresses and port options.
 #   $nameservers = { 'dns1' => '10.0.0.1:53', 'dns2' => '10.0.0.2:53' }
+#   Either the 'nameservers' or the 'parse_resolv_conf' parameter must be
+#   specified in order for the resolver to work.
+#   Default: none specified.
+#
+# @param parse_resolv_conf
+#   If true, parse resolv.conf to retrieve an ordered set of nameservers.
+#   This can be used instead of (or in addition to) the 'nameservers'
+#   parameter.
+#   Default: false
 #
 # @param hold
 #   Defines <period> during which the last name resolution should be kept
@@ -87,7 +96,8 @@
 # Ricardo Rosales <missingcharacter@gmail.com>
 #
 define haproxy::resolver (
-  $nameservers             = undef,
+  Hash $nameservers       = {},
+  Boolean $parse_resolv_conf = false,
   $hold                    = undef,
   $resolve_retries         = undef,
   $timeout                 = undef,

--- a/manifests/resolver.pp
+++ b/manifests/resolver.pp
@@ -97,18 +97,18 @@
 #
 define haproxy::resolver (
   Hash $nameservers       = {},
-  Boolean $parse_resolv_conf = false,
-  $hold                    = undef,
-  $resolve_retries         = undef,
-  $timeout                 = undef,
+  Boolean $parse_resolv_conf                          = false,
+  $hold                                               = undef,
+  $resolve_retries                                    = undef,
+  $timeout                                            = undef,
   # https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.3.2-accepted_payload_size
   Optional[Integer[512, 8192]] $accepted_payload_size = undef,
-  $instance                = 'haproxy',
-  $section_name            = $name,
-  $sort_options_alphabetic = undef,
-  $collect_exported        = true,
-  $config_file             = undef,
-  $defaults                = undef,
+  $instance                                           = 'haproxy',
+  $section_name                                       = $name,
+  $sort_options_alphabetic                            = undef,
+  $collect_exported                                   = true,
+  $config_file                                        = undef,
+  $defaults                                           = undef,
 ) {
   include haproxy::params
 

--- a/spec/defines/resolver_spec.rb
+++ b/spec/defines/resolver_spec.rb
@@ -20,6 +20,26 @@ describe 'haproxy::resolver' do
         hold: { 'other' => '30s', 'refused' => '30s', 'nx' => '30s', 'timeout' => '30s', 'valid' => '10s' },
         resolve_retries: 3,
         timeout: { 'retry' => '1s' },
+      }
+    end
+
+    it {
+      is_expected.to contain_concat__fragment('haproxy-bar_resolver_block').with(
+        'order'   => '20-bar-01',
+        'target'  => '/etc/haproxy/haproxy.cfg',
+        'content' => "\nresolvers bar\n  nameserver dns1 1.1.1.1:53\n  nameserver dns2 1.1.1.2:53\n  resolve_retries 3\n  timeout retry 1s\n  hold other 30s\n  hold refused 30s\n  hold nx 30s\n  hold timeout 30s\n  hold valid 10s\n", # rubocop:disable Layout/LineLength
+      )
+    }
+  end
+
+  context 'with accepted_payload_size within range' do
+    let(:title) { 'bar' }
+    let(:params) do
+      {
+        nameservers: { 'dns1' => '1.1.1.1:53', 'dns2' => '1.1.1.2:53' },
+        hold: { 'other' => '30s', 'refused' => '30s', 'nx' => '30s', 'timeout' => '30s', 'valid' => '10s' },
+        resolve_retries: 3,
+        timeout: { 'retry' => '1s' },
         accepted_payload_size: 512,
       }
     end
@@ -45,7 +65,7 @@ describe 'haproxy::resolver' do
       }
     end
 
-    it { is_expected.to compile.and_raise_error(%r{accepted_payload_size must be atleast 512 and not more than 8192}) }
+    it { is_expected.to compile.and_raise_error(%r{expects a value of type Undef or Integer\[512, 8192\]}) }
   end
 
   context 'with accepted_payload_size too large' do
@@ -60,6 +80,6 @@ describe 'haproxy::resolver' do
       }
     end
 
-    it { is_expected.to compile.and_raise_error(%r{accepted_payload_size must be atleast 512 and not more than 8192}) }
+    it { is_expected.to compile.and_raise_error(%r{expects a value of type Undef or Integer\[512, 8192\]}) }
   end
 end

--- a/spec/defines/resolver_spec.rb
+++ b/spec/defines/resolver_spec.rb
@@ -32,6 +32,26 @@ describe 'haproxy::resolver' do
     }
   end
 
+  context 'with parse_resolv_conf' do
+    let(:title) { 'bar' }
+    let(:params) do
+      {
+        parse_resolv_conf: true,
+        hold: { 'other' => '30s', 'refused' => '30s', 'nx' => '30s', 'timeout' => '30s', 'valid' => '10s' },
+        resolve_retries: 3,
+        timeout: { 'retry' => '1s' },
+      }
+    end
+
+    it {
+      is_expected.to contain_concat__fragment('haproxy-bar_resolver_block').with(
+        'order'   => '20-bar-01',
+        'target'  => '/etc/haproxy/haproxy.cfg',
+        'content' => "\nresolvers bar\n  parse-resolv-conf\n  resolve_retries 3\n  timeout retry 1s\n  hold other 30s\n  hold refused 30s\n  hold nx 30s\n  hold timeout 30s\n  hold valid 10s\n",
+      )
+    }
+  end
+
   context 'with accepted_payload_size within range' do
     let(:title) { 'bar' }
     let(:params) do

--- a/templates/haproxy_resolver_block.erb
+++ b/templates/haproxy_resolver_block.erb
@@ -3,6 +3,9 @@ resolvers <%= @section_name %>
 <% @nameservers.each do |id, nameserver| -%>
   nameserver <%= id %> <%= nameserver %>
 <% end -%>
+<% if @parse_resolv_conf -%>
+  parse-resolv-conf
+<% end -%>
 <% if @resolve_retries -%>
   resolve_retries <%= @resolve_retries %>
 <% end -%>


### PR DESCRIPTION
This fixes two separate issues with the `resolver` defined type:
1. The `accepted_payload_size` puppet parameter must be specified, despite HAProxy itself allowing the corresponding option to be unspecified.
2. The `parse-resolv-conf` HAProxy option is not supported.

I have updated the tests accordingly.
