### PR TITLE
defaults section overhaul - adding support of named defaults in other sections

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -1,6 +1,6 @@
 # @summary
 #   This type will setup a backend service configuration block inside the
-#   haproxy.cfg file on an haproxy load balancer. 
+#   haproxy.cfg file on an haproxy load balancer.
 # @note
 #   Each backend service needs one
 #   or more backend member servers (that can be declared with the
@@ -49,7 +49,7 @@
 # @param defaults
 #   Name of the defaults section this backend will use.
 #   Defaults to undef which means the global defaults section will be used.
-# 
+#
 # @param instance
 #   Optional. Defaults to 'haproxy'
 #
@@ -119,15 +119,9 @@ define haproxy::backend (
     }
   }
 
-  if $defaults == undef {
-    $order = "20-${section_name}-00"
-  } else {
-    $order = "25-${defaults}-${section_name}-01"
-  }
-
   # Template uses: $section_name, $ipaddress, $ports, $options
   concat::fragment { "${instance_name}-${section_name}_backend_block":
-    order   => $order,
+    order   => "20-${section_name}-00",
     target  => $_config_file,
     content => template('haproxy/haproxy_backend_block.erb'),
   }

--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -1,7 +1,7 @@
 # @summary
 #  This type will setup a balancer member inside a listening service
 #  configuration block in /etc/haproxy/haproxy.cfg on the load balancer.
-#  
+#
 # @note
 #  Currently it only has the ability to specify the instance name,
 #  ip address, port, and whether or not it is a backup. More features
@@ -162,14 +162,9 @@ define haproxy::balancermember (
     $_config_file = pick($config_file, inline_template($haproxy::params::config_file_tmpl))
   }
 
-  if $defaults == undef {
-    $order = "20-${listening_service}-01-${name}"
-  } else {
-    $order = "25-${defaults}-${listening_service}-02-${name}"
-  }
   # Template uses $ipaddresses, $server_name, $ports, $option
   concat::fragment { "${instance_name}-${listening_service}_balancermember_${name}":
-    order   => $order,
+    order   => "20-${listening_service}-01-${name}",
     target  => $_config_file,
     content => template('haproxy/haproxy_balancermember.erb'),
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,6 @@ define haproxy::config (
   $instance_name,
   $config_file,
   $global_options,
-  $defaults_options,
   $package_ensure,
   $chroot_dir_manage,
   $config_dir = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
@@ -21,10 +20,8 @@ define haproxy::config (
 
   if $merge_options {
     $_global_options   = merge($haproxy::params::global_options, $global_options)
-    $_defaults_options = merge($haproxy::params::defaults_options, $defaults_options)
   } else {
     $_global_options   = $global_options
-    $_defaults_options = $defaults_options
     warning("${module_name}: The \$merge_options parameter will default to true in the next major release. Please review the documentation regarding the implications.") # lint:ignore:140chars
   }
 
@@ -74,7 +71,7 @@ define haproxy::config (
       content => "# This file is managed by Puppet\n",
     }
 
-    # Template uses $_global_options, $_defaults_options, $custom_fragment
+    # Template uses $_global_options, $custom_fragment
     concat::fragment { "${instance_name}-haproxy-base":
       target  => $_config_file,
       order   => '10',

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -1,16 +1,23 @@
 # @summary
-#  This type will setup a additional defaults configuration block inside the
-#  haproxy.cfg file on an haproxy load balancer. 
+#  This type will setup a defaults configuration block inside the haproxy.cfg
+#  file on an haproxy load balancer.
 #
 # @note
-#  A new default configuration block resets all defaults of prior defaults configuration blocks.
-#  Listener, Backends, Frontends and Balancermember can be configured behind a default
+#  The hash 'defaults_options' will be used as last defaults block below any optional other named default blocks.
+#  The define 'haproxy::defaults' can be used to add named default configuration blocks.
+#  A named default configuration block resets all defaults of prior defaults configuration blocks.
+#  Listener, Backends, Frontends and Balancermember can inherit a default
 #  configuration block by setting the defaults parameter to the corresponding
 #  defaults name.
 #
-#
-# @param options
+# @param defaults_options
 #   A hash of options that are inserted into the defaults configuration block.
+#
+# @param merge_options
+#   Whether to merge the user-supplied options hash with their default
+#   values set in params.pp. Effects only the 'unnamed' defaults section.
+#   Merging allows to change or add options without having to recreate
+#   the entire hash. Defaults to false, but will default to true in future releases.
 #
 # @param sort_options_alphabetic
 #   Sort options either alphabetic or custom like haproxy internal sorts them.
@@ -20,24 +27,37 @@
 #   Optional. Defaults to 'haproxy'.
 #
 define haproxy::defaults (
-  $options                 = {},
-  $sort_options_alphabetic = undef,
-  $instance                = 'haproxy',
+  Boolean $merge_options                           = $haproxy::merge_options,
+  Hash $defaults_options                           = {},
+  String $instance                                 = 'haproxy',
+  Variant[Undef, Boolean] $sort_options_alphabetic = undef,
 ) {
   if $instance == 'haproxy' {
-    include ::haproxy
+    include haproxy
     $instance_name = 'haproxy'
     $config_file = $haproxy::config_file
   } else {
-    include ::haproxy::params
+    include haproxy::params
     $instance_name = "haproxy-${instance}"
     $config_file = inline_template($haproxy::params::config_file_tmpl)
   }
-  include ::haproxy::globals
+
+  include haproxy::globals
   $_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
 
+  if $name == 'haproxy' { # when called from haproxy::instance
+    if $merge_options {
+      $options = merge($haproxy::params::defaults_options, $defaults_options)
+    } else {
+      $options = $defaults_options
+      warning("${module_name}: The \$merge_options parameter will default to true in the next major release. Please review the documentation regarding the implications.") # lint:ignore:140chars
+    }
+  } else {
+    $options = $defaults_options
+  }
+
   concat::fragment { "${instance_name}-${name}_defaults_block":
-    order   => "25-${name}",
+    order   => '12',
     target  => $config_file,
     content => template('haproxy/haproxy_defaults_block.erb'),
   }

--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -51,12 +51,6 @@
 #   Name of the defaults section this backend will use.
 #   Defaults to undef which means the global defaults section will be used.
 #
-# @param defaults_use_backend
-#   If defaults are used and a default backend is configured use the backend
-#   name for ordering. This means that the frontend is placed in the
-#   configuration file before the backend configuration.
-#   Defaults to true.
-#
 # @param config_file
 #   Optional. Path of the config file where this entry will be added.
 #   Assumes that the parent directory exists.
@@ -106,7 +100,6 @@ define haproxy::frontend (
   $sort_options_alphabetic                     = undef,
   $description                                 = undef,
   $defaults                                    = undef,
-  $defaults_use_backend                        = true,
   Optional[Stdlib::Absolutepath] $config_file  = undef,
   # Deprecated
   $bind_options                                = '',
@@ -134,18 +127,9 @@ define haproxy::frontend (
   include haproxy::globals
   $_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
 
-  if $defaults == undef {
-    $order = "15-${section_name}-00"
-  } else {
-    if $defaults_use_backend and has_key($options, 'default_backend') {
-      $order = "25-${defaults}-${options['default_backend']}-00-${section_name}"
-    } else {
-      $order = "25-${defaults}-${section_name}-00"
-    }
-  }
   # Template uses: $section_name, $ipaddress, $ports, $options
   concat::fragment { "${instance_name}-${section_name}_frontend_block":
-    order   => $order,
+    order   => "15-${section_name}-00",
     target  => $_config_file,
     content => template('haproxy/haproxy_frontend_block.erb'),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,7 +85,7 @@
 #   Default /usr/sbin/haproxy -f % -c
 #
 # @param manage_config_dir
-#   Optional. 
+#   Optional.
 # @param manage_service
 #   Deprecated
 # @param enable

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,6 +1,6 @@
 # @summary
 #   Manages haproxy permitting multiple instances to run on the same machine.
-#   
+#
 # @note
 #   Normally users use the Class['haproxy'], which runs a single haproxy
 #   daemon on a machine.
@@ -215,12 +215,16 @@ define haproxy::instance (
     config_dir          => $_config_dir,
     config_file         => $_config_file,
     global_options      => $_global_options,
-    defaults_options    => $_defaults_options,
     custom_fragment     => $custom_fragment,
     merge_options       => $merge_options,
     package_ensure      => $package_ensure,
     chroot_dir_manage   => $chroot_dir_manage,
     config_validate_cmd => $config_validate_cmd,
+  }
+  haproxy::defaults { $title:
+    defaults_options => $_defaults_options,
+    instance         => $instance_name,
+    merge_options    => $merge_options,
   }
   haproxy::install { $title:
     package_name   => $package_name,

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -1,6 +1,6 @@
 # @summary
 #   This type will setup a listening service configuration block inside
-#   the haproxy.cfg file on an haproxy load balancer. 
+#   the haproxy.cfg file on an haproxy load balancer.
 #
 # @note
 #   Each listening service
@@ -144,15 +144,9 @@ define haproxy::listen (
   include haproxy::globals
   $_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
 
-  if $defaults == undef {
-    $order = "20-${section_name}-00"
-  } else {
-    $order = "25-${defaults}-${section_name}-00"
-  }
-
   # Template uses: $section_name, $ipaddress, $ports, $options
   concat::fragment { "${instance_name}-${section_name}_listen_block":
-    order   => $order,
+    order   => "20-${section_name}-00",
     target  => $_config_file,
     content => template('haproxy/haproxy_listen_block.erb'),
   }

--- a/templates/haproxy-base.cfg.erb
+++ b/templates/haproxy-base.cfg.erb
@@ -11,18 +11,6 @@ global
 <% end -%>
 <% end -%>
 
-defaults
-<% @_defaults_options.sort.each do |key,val| -%>
-<%# Skip options whose value is undef/nil -%>
-<% next if val == :undef or val.nil? -%>
-<% if val.is_a?(Array) -%>
-<% val.each do |item| -%>
-  <%= key %>  <%= item %>
-<% end -%>
-<% else -%>
-  <%= key %>  <%= val %>
-<% end -%>
-<% end -%>
 <% if @custom_fragment -%>
 
 <%= @custom_fragment %>

--- a/templates/haproxy_backend_block.erb
+++ b/templates/haproxy_backend_block.erb
@@ -1,5 +1,5 @@
 
-backend <%= @section_name %>
+backend <%= @section_name %><% if @defaults %> from <%= @defaults %><% end %>
 <%= scope.function_template(['haproxy/fragments/_mode.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_description.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_options.erb']) -%>

--- a/templates/haproxy_defaults_block.erb
+++ b/templates/haproxy_defaults_block.erb
@@ -1,4 +1,17 @@
-
-
+<% if @name != 'haproxy' -%>
 defaults <%= @name %>
-<%= scope.function_template(['haproxy/fragments/_options.erb']) -%>
+<%= scope.function_template(['haproxy/fragments/_options.erb']) %>
+<% else -%>
+defaults
+<% @options.sort.each do |key,val| -%>
+<%# Skip options whose value is undef/nil -%>
+<% next if val == :undef or val.nil? -%>
+<% if val.is_a?(Array) -%>
+<% val.each do |item| -%>
+  <%= key %>  <%= item %>
+<% end -%>
+<% else -%>
+  <%= key %>  <%= val %>
+<% end -%>
+<% end -%>
+<% end -%>

--- a/templates/haproxy_frontend_block.erb
+++ b/templates/haproxy_frontend_block.erb
@@ -1,5 +1,5 @@
 
-frontend <%= @section_name %>
+frontend <%= @section_name %><% if @defaults %> from <%= @defaults %><% end %>
 <%= scope.function_template(['haproxy/fragments/_bind.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_mode.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_description.erb']) -%>

--- a/templates/haproxy_listen_block.erb
+++ b/templates/haproxy_listen_block.erb
@@ -1,5 +1,5 @@
 
-listen <%= @section_name %>
+listen <%= @section_name %><% if @defaults %> from <%= @defaults %><% end %>
 <%= scope.function_template(['haproxy/fragments/_bind.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_mode.erb']) -%>
 <%= scope.function_template(['haproxy/fragments/_description.erb']) -%>


### PR DESCRIPTION
Hi there,

this request attempts to overhaul the defaults section handling.
Since HAProxy 2.4 it's possible to inherit a named default section on frontend/backend/listen sections. This makes it unnecessary to put frontend/backend/listen section right behind such a named default block.
An example can be found in the HAProxy blog post [Announcing HAProxy 2.4](https://www.haproxy.com/de/blog/announcing-haproxy-2-4/) below the headline *Named Defaults*.

While implementing this option I stumbled over two things to discuss:

1) How's about removing the `$defaults_options` from params.pp? The defaults set there are round about 10 years old. HAProxy has greatly evolved over time and starts with sane defaults I'd say. It's not even required to provide any `defaults` section anymore to start HAProxy.
Removing `$defaults_options` would also remove the need of merging the hash with a user provided one.
2) The way HAProxy requires the named defaults to be ordered is contrary to the ordering behavior of `concat::fragment`. In order to inherit a named default in HAProxy it needs to be place above the first inheritance. Otherwise HAProxy complains it can't find it.
   `concat::fragment` [orders](https://github.com/puppetlabs/puppetlabs-concat/blob/v7.2.0/manifests/fragment.pp#L8-L10) fragments with the same order number alphabetical. As all defaults have the order 12 it will order them alphabetical, not in the order provided by manifest oder Hiera. This leads to a un-loadable config for HAProxy.
   To bypass this I did this in my tests:
    ```puppet
    my_module::defaults:
      10_de_mydefault:
        defaults_options:
          maxconn: 1024
          mode: http
          balance: roundrobin
          default-server:
            - 'check'
            - 'init-addr last,libc,none'
            - 'inter 10s'
            - 'slowstart 2m'
      de_http from 10_de_mydefault:
        defaults_options:
          option:
            - 'forwardfor except 127.0.0.1'
      de_tcp from 10_de_mydefault:
        defaults_options:
          mode: 'tcp'
    ```
    The "first to be" section has been prefixed with an integer to overcome the `concat::fragment` default sorting. Does anybody got a better idea?


Please let me know what you think and what can be improved on this request.