### PR TITLE
(MAINT) Add support for Ubuntu 22.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7", 
+        "7",
         "8"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
+        "7", 
         "8"
       ]
     },
@@ -59,7 +59,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this commit:
- Support for Ubuntu 22.04 was added.

The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html