### PR TITLE
(CONT-173) - Updating deprecated facter instances

### DIFF
--- a/lib/facter/haproxy_version.rb
+++ b/lib/facter/haproxy_version.rb
@@ -13,10 +13,10 @@
 # Notes:
 #   None
 # workaround Ubuntu 12.04: https://tickets.puppetlabs.com/browse/MODULES-2881
-if defined?(Facter::Util::Resolution.which) && Facter::Util::Resolution.which('haproxy')
+if defined?(Facter::Core::Execution.which) && Facter::Core::Execution.which('haproxy')
   Facter.add('haproxy_version') do
     haproxy_version_cmd = 'haproxy -v 2>&1'
-    haproxy_version_result = Facter::Util::Resolution.exec(haproxy_version_cmd)
+    haproxy_version_result = Facter::Core::Execution.execute(haproxy_version_cmd)
     setcode do
       haproxy_version_result.to_s.lines.first.strip.split(%r{HA?.Proxy})[1].strip.split(%r{version})[1].strip.split(%r{((\d+\.){2,}\d+).*})[1]
     end

--- a/spec/unit/facter/haproxy_version_spec.rb
+++ b/spec/unit/facter/haproxy_version_spec.rb
@@ -13,16 +13,16 @@ describe Facter::Util::Fact do # rubocop:disable RSpec/FilePath
       Copyright 2000-2014 Willy Tarreau <w@1wt.eu>
     PUPPETCODE
     it do
-      expect(Facter::Util::Resolution).to receive(:which).at_least(1).with('haproxy').and_return(true)
-      expect(Facter::Util::Resolution).to receive(:exec).at_least(1).with('haproxy -v 2>&1').and_return(haproxy_version_output)
+      expect(Facter::Core::Execution).to receive(:which).at_least(1).with('haproxy').and_return(true)
+      expect(Facter::Core::Execution).to receive(:execute).at_least(1).with('haproxy -v 2>&1').and_return(haproxy_version_output)
       expect(Facter.fact(:haproxy_version).value).to eq '1.5.3'
     end
   end
 
   context 'when haproxy is not present' do
     it do
-      allow(Facter::Util::Resolution).to receive(:exec)
-      expect(Facter::Util::Resolution).to receive(:which).at_least(1).with('haproxy').and_return(false)
+      allow(Facter::Core::Execution).to receive(:execute)
+      expect(Facter::Core::Execution).to receive(:which).at_least(1).with('haproxy').and_return(false)
       expect(Facter.fact(:haproxy_version)).to be_nil
     end
   end


### PR DESCRIPTION
Prior to this PR, this module contained instances of Facter::Util::Resolution.exec and Facter::Util::Resolution.which, which are deprecated. 
This PR aims to replace these exec helpers with their supported Facter::Core::Execution counterparts.

This PR:
- Replaces all Facter::Util::Resolution instances with corresponding Facter::Core::Execution exec helpers