### PR TITLE
(CONT-651) Adjusting datatypes

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -138,7 +138,7 @@ define haproxy::balancermember (
   String                                              $listening_service,
   Enum['server', 'default-server', 'server-template'] $type               = 'server',
   Optional[Variant[Array, String]]                    $ports              = undef,
-  Optional[Variant[String]]                           $port               = undef,
+  Optional[Variant[String, Stdlib::Port]]             $port               = undef,
   Variant[String[1], Array]                           $server_names       = $hostname,
   Variant[String, Array]                              $ipaddresses        = $ipaddress,
   String                                              $prefix             = 'server',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,15 +3,15 @@
 # @api private
 define haproxy::config (
   # lint:ignore:140chars
+  Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]] $package_ensure,
   String                                $instance_name,
   Stdlib::Absolutepath                  $config_file,
   Hash                                  $global_options,
   Hash                                  $defaults_options,
-  String[1]                             $package_ensure,
   Boolean                               $chroot_dir_manage,
-  Stdlib::Absolutepath                  $config_dir = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
-  Optional[String]                      $custom_fragment = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed. << Update 15/12/22 This still needs a default.
-  Boolean                               $merge_options = $haproxy::merge_options,
+  Stdlib::Absolutepath                  $config_dir          = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
+  Optional[String]                      $custom_fragment     = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed. << Update 15/12/22 This still needs a default.
+  Boolean                               $merge_options       = $haproxy::merge_options,
   Variant[Stdlib::Absolutepath, String] $config_validate_cmd = $haproxy::config_validate_cmd,
   # lint:endignore
 ) {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,8 +9,8 @@ define haproxy::config (
   Hash                                  $global_options,
   Hash                                  $defaults_options,
   Boolean                               $chroot_dir_manage,
-  Stdlib::Absolutepath                  $config_dir          = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
-  Optional[String]                      $custom_fragment     = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed. << Update 15/12/22 This still needs a default.
+  Stdlib::Absolutepath                  $config_dir          = undef,
+  Optional[String]                      $custom_fragment     = undef,
   Boolean                               $merge_options       = $haproxy::merge_options,
   Variant[Stdlib::Absolutepath, String] $config_validate_cmd = $haproxy::config_validate_cmd,
   # lint:endignore

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,7 +120,7 @@
 #  }
 #
 class haproxy (
-  String[1]                                     $package_ensure       = 'present',
+  Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]] $package_ensure = 'present',
   String                                        $package_name         = $haproxy::params::package_name,
   Variant[Enum['running', 'stopped'], Boolean]  $service_ensure       = 'running',
   Boolean                                       $service_manage       = true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@
 # @api private
 define haproxy::install (
   # lint:ignore:140chars
-  String[1]         $package_ensure,
+  Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]] $package_ensure,
   Optional[String]  $package_name     = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   # lint:endignore
 ) {

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -159,22 +159,22 @@
 #   call haproxy::instance_service.
 #
 define haproxy::instance (
-  Optional[String]                              $package_name         = undef,
-  String[1]                                     $package_ensure       = 'present',
-  Variant[Enum['running', 'stopped'], Boolean]  $service_ensure       = 'running',
-  Boolean                                       $service_manage       = true,
-  Boolean                                       $chroot_dir_manage    = true,
-  Optional[String]                              $service_name         = undef,
-  Optional[Hash]                                $global_options       = undef,
-  Optional[Hash]                                $defaults_options     = undef,
-  Optional[String]                              $restart_command      = undef,
-  Optional[String]                              $custom_fragment      = undef,
-  Optional[Stdlib::Absolutepath]                $config_dir           = undef,
-  Optional[Stdlib::Absolutepath]                $config_file          = undef,
-  Variant[Stdlib::Absolutepath, String]         $config_validate_cmd  = $haproxy::params::config_validate_cmd,
-  Boolean                                       $merge_options        = $haproxy::params::merge_options,
-  String                                        $service_options      = $haproxy::params::service_options,
-  String                                        $sysconfig_options    = $haproxy::params::sysconfig_options,
+  Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]] $package_ensure = 'present',
+  Optional[String]                             $package_name         = undef,
+  Variant[Enum['running', 'stopped'], Boolean] $service_ensure       = 'running',
+  Boolean                                      $service_manage       = true,
+  Boolean                                      $chroot_dir_manage    = true,
+  Optional[String]                             $service_name         = undef,
+  Optional[Hash]                               $global_options       = undef,
+  Optional[Hash]                               $defaults_options     = undef,
+  Optional[String]                             $restart_command      = undef,
+  Optional[String]                             $custom_fragment      = undef,
+  Optional[Stdlib::Absolutepath]               $config_dir           = undef,
+  Optional[Stdlib::Absolutepath]               $config_file          = undef,
+  Variant[Stdlib::Absolutepath, String]        $config_validate_cmd  = $haproxy::params::config_validate_cmd,
+  Boolean                                      $merge_options        = $haproxy::params::merge_options,
+  String                                       $service_options      = $haproxy::params::service_options,
+  String                                       $sysconfig_options    = $haproxy::params::sysconfig_options,
 ) {
   # Since this is a 'define', we can not use 'inherts haproxy::params'.
   # Therefore, we "include haproxy::params" for any parameters we need.

--- a/manifests/mailer.pp
+++ b/manifests/mailer.pp
@@ -33,11 +33,11 @@
 #  The instance name of the mailer entry. Default value: 'haproxy'.
 #
 define haproxy::mailer (
-  String                    $mailers_name,
-  Variant[String, Integer]  $port,
-  Variant[String[1], Array] $server_names = $hostname,
-  Variant[String, Array]    $ipaddresses  = $ipaddress,
-  String                    $instance     = 'haproxy',
+  String                        $mailers_name,
+  Variant[String, Stdlib::Port] $port,
+  Variant[String[1], Array]     $server_names = $hostname,
+  Variant[String, Array]        $ipaddresses  = $ipaddress,
+  String                        $instance     = 'haproxy',
 ) {
   include haproxy::params
   if $instance == 'haproxy' {

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -39,7 +39,7 @@
 #
 define haproxy::peer (
   String                          $peers_name,
-  Variant[String, Integer]        $port,
+  Variant[String, Stdlib::Port]   $port,
   Variant[String[1], Array]       $server_names = $hostname,
   Variant[String, Array]          $ipaddresses  = $ipaddress,
   String                          $instance     = 'haproxy',


### PR DESCRIPTION
Prior to this commit, there was an module update that assigned datatypes to all parameters in the module. However, some of these datatypes proved to be either too generic to properly enforce a value or not comprehensive enough to develop proper documentation around it.

This commit adjust these datatypes so that they fit better the parameters they define.