### PR TITLE
(CONT-880) Update concat dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.3 < 8.0.0"
+      "version_requirement": ">= 1.2.3 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Following the last major version update for puppetlabs-concat, several modules found themselves needing a dependency update. This commit aims to adjust the concat dependency within the module so that it is compatible with concat 9.0.0 and onwards.