### PR TITLE
Correct warnings about deprecated parameter

### DIFF
--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -117,7 +117,7 @@ define haproxy::frontend (
   if $ipaddress and $bind {
     fail('The use of $ipaddress and $bind is mutually exclusive, please choose either one')
   }
-  if $bind_options != '' {
+  if $bind_options {
     warning('The $bind_options parameter is deprecated; please use $bind instead')
   }
 

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -123,7 +123,7 @@ define haproxy::listen (
   if $ipaddress == undef and $bind == undef {
     fail('Either $ipaddress or $bind is needed, please choose one')
   }
-  if $bind_options                            != '' {
+  if $bind_options {
     warning('The $bind_options parameter is deprecated; please use $bind instead')
   }
 


### PR DESCRIPTION
Haproxy is emitting a warning: "The $bind_options parameter is deprecated; please use $bind instead"

This occurs even when bind_options is NOT being used.

See issue #555 