### PR TITLE
(maint) fix concat version in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.3 < 9.0.0"
+      "version_requirement": ">= 1.2.3 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
## Summary
specs are failing due to non-matching concat version

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)