### PR TITLE
dependency: create mapfile before configfile

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -57,6 +57,7 @@ define haproxy::config (
       owner => '0',
       group => '0',
       mode  => '0640',
+      tag   => 'haproxy-config',
     }
 
     Concat[$_config_file] {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,6 +147,9 @@ class haproxy (
   # there should be no legacy code that uses these deprecated
   # parameters.
 
+  Haproxy::Mapfile <| |>
+  -> Concat <| tag=='haproxy-config' |>
+
   # To support deprecating $enable
   if $enable != undef {
     warning('The $enable parameter is deprecated; please use service_ensure and/or package_ensure instead')


### PR DESCRIPTION
configcheck fails, if the mapfile does not exist

## Summary
add dependency to create mapfile before configfiles

## Additional Context
creating a config referencing a mapfile will never succed since the config check of the configuration fails 
with the mapfile not existing.

## Related Issues (if any)
none

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)