### PR TITLE
make picking haproxy::globals::sort_options_alphabetic work

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -44,7 +44,7 @@
 #
 # @param sort_options_alphabetic
 #   Sort options either alphabetic or custom like haproxy internal sorts them.
-#   Defaults to true.
+#   Defaults to undef (picking true from $haproxy::globals::sort_options_alphabetic).
 #
 # @param defaults
 #   Name of the defaults section this backend will use.
@@ -77,7 +77,7 @@ define haproxy::backend (
   },
   String                                  $instance                 = 'haproxy',
   String[1]                               $section_name             = $name,
-  Boolean                                 $sort_options_alphabetic  = true,
+  Optional[Boolean]                       $sort_options_alphabetic  = undef,
   Optional[String]                        $description              = undef,
   Optional[String]                        $defaults                 = undef,
   Optional[Stdlib::Absolutepath]          $config_file              = undef,

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -14,15 +14,15 @@
 #
 # @param sort_options_alphabetic
 #   Sort options either alphabetic or custom like haproxy internal sorts them.
-#   Defaults to true.
+#   Defaults to undef (picking true from $haproxy::globals::sort_options_alphabetic).
 #
 # @param instance
 #   Optional. Defaults to 'haproxy'.
 #
 define haproxy::defaults (
-  Hash    $options                  = {},
-  Boolean $sort_options_alphabetic  = true,
-  String  $instance                 = 'haproxy',
+  Hash              $options                  = {},
+  Optional[Boolean] $sort_options_alphabetic  = undef,
+  String            $instance                 = 'haproxy',
 ) {
   if $instance == 'haproxy' {
     include haproxy

--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -45,7 +45,7 @@
 #
 # @param sort_options_alphabetic
 #   Sort options either alphabetic or custom like haproxy internal sorts them.
-#   Defaults to true.
+#   Defaults to undef (picking true from $haproxy::globals::sort_options_alphabetic).
 #
 # @param defaults
 #   Name of the defaults section this backend will use.
@@ -103,7 +103,7 @@ define haproxy::frontend (
   },
   String                                  $instance                 = 'haproxy',
   String[1]                               $section_name             = $name,
-  Boolean                                 $sort_options_alphabetic  = true,
+  Optional[Boolean]                       $sort_options_alphabetic  = undef,
   Optional[String]                        $description              = undef,
   Optional[String]                        $defaults                 = undef,
   Boolean                                 $defaults_use_backend     = true,

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -61,7 +61,7 @@
 #
 # @param sort_options_alphabetic
 #   Sort options either alphabetic or custom like haproxy internal sorts them.
-#   Defaults to true.
+#   Defaults to undef (picking true from $haproxy::globals::sort_options_alphabetic).
 #
 # @param defaults
 #   Name of the defaults section this backend will use.
@@ -107,7 +107,7 @@ define haproxy::listen (
   },
   String                                  $instance                 = 'haproxy',
   String[1]                               $section_name             = $name,
-  Boolean                                 $sort_options_alphabetic  = true,
+  Optional[Boolean]                       $sort_options_alphabetic  = undef,
   Optional[String]                        $description              = undef,
   Optional[String]                        $defaults                 = undef,
   Optional[Stdlib::Absolutepath]          $config_file              = undef,

--- a/manifests/resolver.pp
+++ b/manifests/resolver.pp
@@ -62,7 +62,7 @@
 #
 # @param sort_options_alphabetic
 #   Sort options either alphabetic or custom like haproxy internal sorts them.
-#   Defaults to true.
+#   Defaults to undef (picking true from $haproxy::globals::sort_options_alphabetic).
 #
 # @param defaults
 #   Name of the defaults section this backend will use.
@@ -105,7 +105,7 @@ define haproxy::resolver (
   Optional[Integer[512, 8192]]    $accepted_payload_size    = undef,
   String                          $instance                 = 'haproxy',
   String[1]                       $section_name             = $name,
-  Boolean                         $sort_options_alphabetic  = true,
+  Optional[Boolean]               $sort_options_alphabetic  = undef,
   Boolean                         $collect_exported         = true,
   Optional[Stdlib::Absolutepath]  $config_file              = undef,
   Optional[String]                $defaults                 = undef,


### PR DESCRIPTION
all the pick statements for the sort_options_alphabetic are useless, if the value is not optional !

