### PR TITLE
haproxy::backend: Always set $_sort_options_alphabetic

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -109,10 +109,12 @@ define haproxy::backend (
   if $picked_sort_options_alphabetic == false {
     $_sort_options_alphabetic = $picked_sort_options_alphabetic
   } else {
-    if $options.is_a(Hash) and 'option' in $options {
+    if $options =~ Hash and 'option' in $options {
       if ('httpchk' in $options['option']) {
         warning('Overriding the value of $sort_options_alphabetic to "false" due to "httpchk" option defined')
         $_sort_options_alphabetic = false
+      } else {
+        $_sort_options_alphabetic = $picked_sort_options_alphabetic
       }
     } else {
       $_sort_options_alphabetic = $picked_sort_options_alphabetic


### PR DESCRIPTION
Without this there's a possiblity that the variable isn't defined. This leads to an unreferenced variable call in line 133.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)