### PR TITLE
Replace merge() with native puppet code

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,8 +20,8 @@ define haproxy::config (
   }
 
   if $merge_options {
-    $_global_options   = merge($haproxy::params::global_options, $global_options)
-    $_defaults_options = merge($haproxy::params::defaults_options, $defaults_options)
+    $_global_options   = $haproxy::params::global_options + $global_options
+    $_defaults_options = $haproxy::params::defaults_options + $defaults_options
   } else {
     $_global_options   = $global_options
     $_defaults_options = $defaults_options


### PR DESCRIPTION
## Summary

HAproxy 7.2.0 gives a warning:
Warning: This function is deprecated, please use stdlib::merge instead. at ["/etc/puppetlabs/code/environments/staging/r10k/modules/haproxy/manifests/config.pp", 23]:
   (location: /etc/puppetlabs/code/environments/staging/r10k/modules/stdlib/lib/puppet/functions/deprecation.rb:35:in `deprecation')

See Issue # 575
https://github.com/puppetlabs/puppetlabs-haproxy/issues/575

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ X] Manually verified. (For example `puppet apply`)