### PR TITLE
Change indentation for custom_fragments to align with global

### DIFF
--- a/templates/haproxy-base.cfg.epp
+++ b/templates/haproxy-base.cfg.epp
@@ -27,5 +27,5 @@ defaults
 <% } -%>
 <% if $custom_fragment { -%>
 
-  <%= $custom_fragment %>
+<%= $custom_fragment %>
 <% } -%>


### PR DESCRIPTION
## Summary
This formats custom_fragments to align with global and default sections.

## Additional Context
This change allows...
```
  class { 'haproxy':

    custom_fragment  => "cache mycache \n  total-max-size 4095 \n  max-object-size 10000 \n  max-age 30",
    global_options   => {...
    defaults_options => {...
}
```
...to generate `haproxy.cfg`:
```
global
  ...
defaults
  ...
cache mycache 
  total-max-size 4095 
  max-object-size 10000 
  max-age 30
```
## Related Issues (if any)
See #582 

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ x ] Manually verified. (For example `puppet apply`)