### PR TITLE
(CAT-1426)-Removal of redhat/scientific/oraclelinux 6 for haproxy module

### DIFF
--- a/spec/acceptance/userlist_spec.rb
+++ b/spec/acceptance/userlist_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'userlist define', unless: (os[:family] == 'redhat' && os[:release][0] == '5') do
+describe 'userlist define' do
   pp_one = <<-PUPPETCODE
       class { 'haproxy': }
       haproxy::userlist { 'users_groups':

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -44,25 +44,8 @@ RSpec.configure do |c|
 
     if os[:family] == 'redhat' && os[:release].to_i != 8
       epel_owner = 'puppet'
-      epel_owner = 'stahnma' if os[:release].to_i == 6
       LitmusHelper.instance.run_shell("puppet module install #{epel_owner}/epel")
-      if os[:release][0].match?(%r{5|6})
-        pp = <<-PP
-        class { 'epel':
-
-              epel_baseurl => "http://osmirror.delivery.puppetlabs.net/epel${::operatingsystemmajrelease}-\\$basearch/RPMS.all",
-              epel_mirrorlist => "http://osmirror.delivery.puppetlabs.net/epel${::operatingsystemmajrelease}-\\$basearch/RPMS.all",
-
-        }
-        PP
-        LitmusHelper.instance.apply_manifest(pp)
-      else
-        LitmusHelper.instance.run_shell("puppet apply -e 'include epel'")
-      end
-    end
-    if os[:family] == 'redhat' && os[:release].to_i == 6
-      LitmusHelper.instance.run_shell('yum clean all')
-      LitmusHelper.instance.run_shell('yum --disablerepo="epel" update nss -y')
+      LitmusHelper.instance.run_shell("puppet apply -e 'include epel'")
     end
     pp = <<-PP
     package { 'curl': ensure => present, }


### PR DESCRIPTION
## Summary
With the removal of support for RHEL6 from our modules, work must be done to cleanup and remove any residual code.
This PR does the same for haproxy repo module. More info can be found #533 

## Additional Context

## Related Issues (if any)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)