### PR TITLE
fix haproxy::globals::sort_options_alphabetic not being respected

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -77,7 +77,7 @@ define haproxy::backend (
   },
   String                                  $instance                 = 'haproxy',
   String[1]                               $section_name             = $name,
-  Boolean                                 $sort_options_alphabetic  = true,
+  Optional[Boolean]                       $sort_options_alphabetic  = undef,
   Optional[String]                        $description              = undef,
   Optional[String]                        $defaults                 = undef,
   Optional[Stdlib::Absolutepath]          $config_file              = undef,

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -21,7 +21,7 @@
 #
 define haproxy::defaults (
   Hash    $options                  = {},
-  Boolean $sort_options_alphabetic  = true,
+  Optional[Boolean] $sort_options_alphabetic  = undef,
   String  $instance                 = 'haproxy',
 ) {
   if $instance == 'haproxy' {

--- a/manifests/frontend.pp
+++ b/manifests/frontend.pp
@@ -103,7 +103,7 @@ define haproxy::frontend (
   },
   String                                  $instance                 = 'haproxy',
   String[1]                               $section_name             = $name,
-  Boolean                                 $sort_options_alphabetic  = true,
+  Optional[Boolean]                       $sort_options_alphabetic  = undef,
   Optional[String]                        $description              = undef,
   Optional[String]                        $defaults                 = undef,
   Boolean                                 $defaults_use_backend     = true,

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -107,7 +107,7 @@ define haproxy::listen (
   },
   String                                  $instance                 = 'haproxy',
   String[1]                               $section_name             = $name,
-  Boolean                                 $sort_options_alphabetic  = true,
+  Optional[Boolean]                        $sort_options_alphabetic  = undef,
   Optional[String]                        $description              = undef,
   Optional[String]                        $defaults                 = undef,
   Optional[Stdlib::Absolutepath]          $config_file              = undef,

--- a/manifests/resolver.pp
+++ b/manifests/resolver.pp
@@ -105,7 +105,7 @@ define haproxy::resolver (
   Optional[Integer[512, 8192]]    $accepted_payload_size    = undef,
   String                          $instance                 = 'haproxy',
   String[1]                       $section_name             = $name,
-  Boolean                         $sort_options_alphabetic  = true,
+  Optional[Boolean]               $sort_options_alphabetic  = undef,
   Boolean                         $collect_exported         = true,
   Optional[Stdlib::Absolutepath]  $config_file              = undef,
   Optional[String]                $defaults                 = undef,


### PR DESCRIPTION
## Summary
I believe commit e0835f86149a4708ae493fb5bf387b61562503f3 and its siblings (if any) to be in error.

## Additional Context
When specifying "haproxy::globals::sort_options_alphabetic: false" it will be overwritten/ignored by 
```
Boolean                                 $sort_options_alphabetic  = true,
```
with
```
$_sort_options_alphabetic = pick($sort_options_alphabetic, $haproxy::globals::sort_options_alphabetic)
```

pick() according to documentation:
"Returns: Any the first value in a list of values that is not undefined or an empty `string.`

If sort_options_alphabetic isn't specifically passed into a listen resource we want to global value to be applied.

Current version of haproxy ignores the global and shuffled all my entries into alphabetical order.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)