### PR TITLE
Add `merge_options` for `haproxy::defaults`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -714,6 +714,7 @@ The following parameters are available in the `haproxy::defaults` defined type:
 
 * [`options`](#-haproxy--defaults--options)
 * [`sort_options_alphabetic`](#-haproxy--defaults--sort_options_alphabetic)
+* [`merge_options`](#-haproxy--defaults--merge_options)
 * [`instance`](#-haproxy--defaults--instance)
 
 ##### <a name="-haproxy--defaults--options"></a>`options`
@@ -732,6 +733,17 @@ Sort options either alphabetic or custom like haproxy internal sorts them.
 Defaults to true.
 
 Default value: `true`
+
+##### <a name="-haproxy--defaults--merge_options"></a>`merge_options`
+
+Data type: `Boolean`
+
+Whether to merge the user-supplied `options` hash with the
+`default_options` values set in params.pp. Merging allows to change
+or add options without having to recreate the entire hash. Defaults to
+false, but will default to true in future releases.
+
+Default value: `$haproxy::params::merge_options`
 
 ##### <a name="-haproxy--defaults--instance"></a>`instance`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -49,6 +49,12 @@ file on an haproxy load balancer.
 * `haproxy::mailer::collect_exported`
 * `haproxy::service`: HAProxy service
 
+### Functions
+
+* [`haproxy::generate_error_message`](#haproxy--generate_error_message): Function created to generate error message. Any string as error message can be passed and the function can be called in epp templates.
+* [`haproxy::sort_bind`](#haproxy--sort_bind)
+* [`haproxy::validate_ip_addr`](#haproxy--validate_ip_addr)
+
 ## Classes
 
 ### <a name="haproxy"></a>`haproxy`
@@ -740,8 +746,7 @@ Data type: `Boolean`
 
 Whether to merge the user-supplied `options` hash with the
 `default_options` values set in params.pp. Merging allows to change
-or add options without having to recreate the entire hash. Defaults to
-false, but will default to true in future releases.
+or add options without having to recreate the entire hash.
 
 Default value: `$haproxy::params::merge_options`
 
@@ -2021,4 +2026,62 @@ Data type: `String`
 Optional. Defaults to 'haproxy'
 
 Default value: `'haproxy'`
+
+## Functions
+
+### <a name="haproxy--generate_error_message"></a>`haproxy::generate_error_message`
+
+Type: Ruby 4.x API
+
+Function created to generate error message. Any string as error message can be passed and the function can
+be called in epp templates.
+
+#### `haproxy::generate_error_message(String $error_message)`
+
+Function created to generate error message. Any string as error message can be passed and the function can
+be called in epp templates.
+
+Returns: `Any`
+
+##### `error_message`
+
+Data type: `String`
+
+
+
+### <a name="haproxy--sort_bind"></a>`haproxy::sort_bind`
+
+Type: Ruby 4.x API
+
+The haproxy::sort_bind function.
+
+#### `haproxy::sort_bind(Hash $bind)`
+
+The haproxy::sort_bind function.
+
+Returns: `Array`
+
+##### `bind`
+
+Data type: `Hash`
+
+
+
+### <a name="haproxy--validate_ip_addr"></a>`haproxy::validate_ip_addr`
+
+Type: Ruby 4.x API
+
+The haproxy::validate_ip_addr function.
+
+#### `haproxy::validate_ip_addr(String $virtual_ip)`
+
+The haproxy::validate_ip_addr function.
+
+Returns: `Boolean`
+
+##### `virtual_ip`
+
+Data type: `String`
+
+
 

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -48,7 +48,6 @@ define haproxy::defaults (
     $_defaults_options = $haproxy::params::defaults_options + $defaults_options
   } else {
     $_defaults_options = $defaults_options
-    warning("${module_name}: The \$merge_options parameter will default to true in the next major release. Please review the documentation regarding the implications.") # lint:ignore:140chars
   }
 
   $parameters = {

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -19,8 +19,7 @@
 # @param merge_options
 #   Whether to merge the user-supplied `options` hash with the
 #   `default_options` values set in params.pp. Merging allows to change
-#   or add options without having to recreate the entire hash. Defaults to
-#   false, but will default to true in future releases.
+#   or add options without having to recreate the entire hash.
 #
 # @param instance
 #   Optional. Defaults to 'haproxy'.

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -26,10 +26,10 @@
 #   Optional. Defaults to 'haproxy'.
 #
 define haproxy::defaults (
-  Optional[Hash] $options                  = {},
-  Boolean        $sort_options_alphabetic  = true,
-  Boolean        $merge_options            = $haproxy::params::merge_options,
-  String         $instance                 = 'haproxy',
+  Hash    $options                  = {},
+  Boolean $sort_options_alphabetic  = true,
+  Boolean $merge_options            = $haproxy::params::merge_options,
+  String  $instance                 = 'haproxy',
 ) {
   if $instance == 'haproxy' {
     include haproxy

--- a/spec/defines/defaults_spec.rb
+++ b/spec/defines/defaults_spec.rb
@@ -37,4 +37,38 @@ describe 'haproxy::defaults' do
       )
     }
   end
+
+  context 'with merge defaults true' do
+    let(:params) do
+      {
+        options: { 'balance' => 'roundrobin' },
+        merge_options: true
+      }
+    end
+
+    defaults_output = <<~EXPECTEDOUTPUT
+
+
+      defaults test
+        balance roundrobin
+        log global
+        maxconn 8000
+        option redispatch
+        retries 3
+        stats enable
+        timeout http-request 10s
+        timeout queue 1m
+        timeout connect 10s
+        timeout client 1m
+        timeout server 1m
+        timeout check 10s
+    EXPECTEDOUTPUT
+    it {
+      is_expected.to contain_concat__fragment('haproxy-test_defaults_block').with(
+        'order' => '25-test',
+        'target' => '/tmp/haproxy.cfg',
+        'content' => defaults_output,
+      )
+    }
+  end
 end

--- a/spec/defines/defaults_spec.rb
+++ b/spec/defines/defaults_spec.rb
@@ -25,7 +25,8 @@ describe 'haproxy::defaults' do
   context 'with a single option' do
     let(:params) do
       {
-        options: { 'balance' => 'roundrobin' }
+        options: { 'balance' => 'roundrobin' },
+        merge_options: false
       }
     end
 
@@ -41,8 +42,7 @@ describe 'haproxy::defaults' do
   context 'with merge defaults true' do
     let(:params) do
       {
-        options: { 'balance' => 'roundrobin' },
-        merge_options: true
+        options: { 'balance' => 'roundrobin' }
       }
     end
 


### PR DESCRIPTION
## Summary
There are default options which would be nice to have in all defaults sections. Add an option to include them.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)