### PR TITLE
merge_options: Switch default false->true

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,7 +25,6 @@ define haproxy::config (
   } else {
     $_global_options   = $global_options
     $_defaults_options = $defaults_options
-    warning("${module_name}: The \$merge_options parameter will default to true in the next major release. Please review the documentation regarding the implications.") # lint:ignore:140chars
   }
 
   if defined(Class['haproxy']) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,8 +6,7 @@
 #   extended by changing package names and configuration file paths.
 #
 class haproxy::params {
-  # XXX: This will change to true in the next major release
-  $merge_options = false
+  $merge_options = true
 
   $service_options  = "ENABLED=1\n"  # Only used by Debian.
   $sysconfig_options = 'OPTIONS=""' #Only used by Redhat/CentOS etc


### PR DESCRIPTION
This was introduced a long time ago:
https://github.com/puppetlabs/puppetlabs-haproxy/commit/8adbf88bc353c3882e9c3a5a3b92e20ffa830f26

I think it's time to finally flip the default value and make a major release.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)