### PR TITLE
update URL for document about contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to Puppet modules
 
-Check out our [Contributing to Supported Modules Blog Post](https://puppetlabs.github.io/iac/docs/contributing_to_a_module.html) to find all the information that you will need.
+Check out our [Contributing to Puppet modules document](https://www.puppet.com/docs/puppet/8/contributing) to find all the information that you will need.


### PR DESCRIPTION
The original page is gone. This document should be an appropriate replacement, though.