### PR TITLE
FreeBSD also uses HAProxy 2.1+ these days, adjust defaults

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,18 +63,19 @@ class haproxy::params {
         'daemon'  => '',
       }
       $defaults_options  = {
-        'log'        => 'global',
-        'mode'       => 'http',
-        'option'     => [
-          'httplog',
-          'dontlognull',
+        'log'     => 'global',
+        'stats'   => 'enable',
+        'option'  => ['redispatch'],
+        'retries' => '3',
+        'timeout' => [
+          'http-request 10s',
+          'queue 1m',
+          'connect 10s',
+          'client 1m',
+          'server 1m',
+          'check 10s',
         ],
-        'retries'    => '3',
-        'redispatch' => '',
-        'maxconn'    => '2000',
-        'contimeout' => '5000',
-        'clitimeout' => '50000',
-        'srvtimeout' => '50000',
+        'maxconn' => '8000',
       }
       $config_validate_cmd = '/usr/local/sbin/haproxy -f % -c'
       # Single instance:


### PR DESCRIPTION
## Summary
HAProxy 2.1+ is available as a package for FreeBSD these days, the current defaults let puppet fail due to the deprecated keywords still being used for its default parameter section

```

[NOTICE]   (60025) : path to executable is /usr/local/sbin/haproxy                                                                 
[ALERT]    (60025) : config : parsing [/usr/local/etc/haproxy.conf20240202-56979-1htrd47:16] : the 'clitimeout' directive is not su
pported anymore since HAProxy 2.1. Use 'timeout client'.                                                                           
[ALERT]    (60025) : config : parsing [/usr/local/etc/haproxy.conf20240202-56979-1htrd47:17] : the 'contimeout' directive is not su
pported anymore since HAProxy 2.1. Use 'timeout connect'.                                                                          
[ALERT]    (60025) : config : parsing [/usr/local/etc/haproxy.conf20240202-56979-1htrd47:24] : keyword 'redispatch' directive is no
t supported anymore since HAProxy 2.1. Use 'option redispatch'.                                                                    
[ALERT]    (60025) : config : parsing [/usr/local/etc/haproxy.conf20240202-56979-1htrd47:26] : the 'srvtimeout' directive is not su
pported anymore since HAProxy 2.1. Use 'timeout server'.                                                                           
```

## Additional Context
Add any additional context about the problem here. 
- How to reproduce: Use a supported release of FreeBSD with the HAProxy package

## Related Issues (if any)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x ] Manually verified. (For example `puppet apply`)