### PR TITLE
Pass install_options to package installer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -134,7 +134,7 @@ class haproxy (
   Hash                                          $global_options       = $haproxy::params::global_options,
   Hash                                          $defaults_options     = $haproxy::params::defaults_options,
   Boolean                                       $merge_options        = $haproxy::params::merge_options,
-  Optional[Array[String]]                       $install_options      = undef,
+  Array[String[1]]                              $install_options      = [],
   Optional[String]                              $restart_command      = undef,
   Optional[String]                              $custom_fragment      = undef,
   Stdlib::Absolutepath                          $config_dir           = $haproxy::params::config_dir,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,9 @@
 #   or add options without having to recreate the entire hash. Defaults to
 #   false, but will default to true in future releases.
 #
+# @param install_options
+#   Array of arguments passed to the installer
+#
 # @param restart_command
 #   Command to use when restarting the on config changes.
 #    Passed directly as the <code>'restart'</code> parameter to the service resource.
@@ -131,6 +134,7 @@ class haproxy (
   Hash                                          $global_options       = $haproxy::params::global_options,
   Hash                                          $defaults_options     = $haproxy::params::defaults_options,
   Boolean                                       $merge_options        = $haproxy::params::merge_options,
+  Optional[Array[String]]                       $install_options      = undef,
   Optional[String]                              $restart_command      = undef,
   Optional[String]                              $custom_fragment      = undef,
   Stdlib::Absolutepath                          $config_dir           = $haproxy::params::config_dir,
@@ -176,6 +180,7 @@ class haproxy (
   haproxy::instance { $title:
     package_ensure      => $_package_ensure,
     package_name        => $package_name,
+    install_options     => $install_options,
     service_ensure      => $_service_ensure,
     service_manage      => $_service_manage,
     service_name        => $service_name,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,11 +1,13 @@
-# @summary 
-#   Install haproxy
+# @summary Install haproxy
+# @param install_options
+#   Array of arguments passed to the installer
 # @api private
 define haproxy::install (
   # lint:ignore:140chars
   Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]] $package_ensure,
   Optional[String]  $package_name     = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
   # lint:endignore
+  Array[String[1]] $install_options = [],
 ) {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
@@ -13,8 +15,9 @@ define haproxy::install (
 
   if $package_name != undef {
     package { $package_name:
-      ensure => $package_ensure,
-      alias  => 'haproxy',
+      ensure          => $package_ensure,
+      install_options => $install_options,
+      alias           => 'haproxy',
     }
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -19,6 +19,9 @@
 #   The package name of haproxy. Defaults to undef, and no package is installed.
 #   NOTE: Class['haproxy'] has a different default.
 #
+# @param install_options
+#   Array of arguments passed to the installer
+#
 # @param service_ensure
 #   Chooses whether the haproxy service should be running & enabled at boot, or
 #   stopped and disabled at boot. Defaults to 'running'
@@ -161,6 +164,7 @@
 define haproxy::instance (
   Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]] $package_ensure = 'present',
   Optional[String]                             $package_name         = undef,
+  Array[String[1]]                             $install_options      = [],
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure       = 'running',
   Boolean                                      $service_manage       = true,
   Boolean                                      $chroot_dir_manage    = true,
@@ -223,8 +227,9 @@ define haproxy::instance (
     config_validate_cmd => $config_validate_cmd,
   }
   haproxy::install { $title:
-    package_name   => $package_name,
-    package_ensure => $package_ensure,
+    package_name    => $package_name,
+    package_ensure  => $package_ensure,
+    install_options => $install_options,
   }
   haproxy::service { $title:
     instance_name     => $instance_service_name,

--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -657,6 +657,25 @@ describe 'haproxy', type: :class do
     end
   end
 
+  context 'when install_options are specified' do
+    let(:facts) do
+      { os: { family: 'Debian' } }.merge default_facts
+    end
+
+    let(:params) do
+      {
+        'install_options' => ['--no-install-recommends'],
+      }
+    end
+
+    it 'installs the haproxy package' do
+      subject.should contain_package('haproxy').with(
+        'ensure'          => 'present',
+        'install_options' => ['--no-install-recommends'],
+      )
+    end
+  end
+
   context 'when on unsupported operatingsystems' do
     let(:facts) do
       { os: { family: 'windows' } }.merge default_facts


### PR DESCRIPTION
## Summary

Allows passing extra parameters to package installer.


## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)