### PR TITLE
Add support for running programs

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -85,7 +85,11 @@ define haproxy::config (
     }
 
     if !empty($programs) {
-      create_resources(haproxy::program, $programs)
+      $programs.each |String $program, Hash $attributes| {
+        Resource['haproxy::program'] { $program:
+          *=> $attributes,
+        }
+      }
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -87,7 +87,7 @@ define haproxy::config (
     if !empty($programs) {
       $programs.each |String $program, Hash $attributes| {
         Resource['haproxy::program'] { $program:
-          *=> $attributes,
+          * => $attributes,
         }
       }
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,7 @@ define haproxy::config (
   Hash                                  $global_options,
   Hash                                  $defaults_options,
   Boolean                               $chroot_dir_manage,
+  Haproxy::Programs                     $programs            = {},
   Stdlib::Absolutepath                  $config_dir          = undef,
   Optional[String]                      $custom_fragment     = undef,
   Boolean                               $merge_options       = $haproxy::merge_options,
@@ -81,6 +82,10 @@ define haproxy::config (
       target  => $_config_file,
       order   => '10',
       content => epp("${module_name}/haproxy-base.cfg.epp", $parameters),
+    }
+
+    if !empty($programs) {
+      create_resources(haproxy::program, $programs)
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,11 @@
 #    Passed directly as the <code>'restart'</code> parameter to the service resource.
 #    Defaults to undef i.e. whatever the service default is.
 #
+# @param programs
+#   A program section contains a set of directives that define the program to be run,
+#   its command-line options and flags, as well as user, group, and restart options.
+#   Note, `master-worker` configuration (in `global_options`) is needed.
+#
 # @param custom_fragment
 #   Allows arbitrary HAProxy configuration to be passed through to support
 #   additional configuration not available via parameters, or to short-circute
@@ -135,6 +140,7 @@ class haproxy (
   Hash                                          $defaults_options     = $haproxy::params::defaults_options,
   Boolean                                       $merge_options        = $haproxy::params::merge_options,
   Array[String[1]]                              $install_options      = [],
+  Haproxy::Programs                             $programs             = {},
   Optional[String]                              $restart_command      = undef,
   Optional[String]                              $custom_fragment      = undef,
   Stdlib::Absolutepath                          $config_dir           = $haproxy::params::config_dir,
@@ -195,5 +201,6 @@ class haproxy (
     service_options     => $service_options,
     sysconfig_options   => $sysconfig_options,
     config_validate_cmd => $config_validate_cmd,
+    programs            => $programs,
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -88,6 +88,10 @@
 #
 # @param sysconfig_options
 #
+# @param programs
+#   A program section contains a set of directives that define the program to be run,
+#   its command-line options and flags, as well as user, group, and restart options.
+#
 # @example
 #  A single instance of haproxy with all defaults
 #  i.e. emulate Class['haproxy']
@@ -179,6 +183,7 @@ define haproxy::instance (
   Boolean                                      $merge_options        = $haproxy::params::merge_options,
   String                                       $service_options      = $haproxy::params::service_options,
   String                                       $sysconfig_options    = $haproxy::params::sysconfig_options,
+  Haproxy::Programs                            $programs             = {},
 ) {
   # Since this is a 'define', we can not use 'inherts haproxy::params'.
   # Therefore, we "include haproxy::params" for any parameters we need.
@@ -225,6 +230,7 @@ define haproxy::instance (
     package_ensure      => $package_ensure,
     chroot_dir_manage   => $chroot_dir_manage,
     config_validate_cmd => $config_validate_cmd,
+    programs            => $programs,
   }
   haproxy::install { $title:
     package_name    => $package_name,

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -1,0 +1,40 @@
+# @summary Program definition
+#
+# A command to be executed by haproxy master process
+#
+# @see https://www.haproxy.com/documentation/haproxy-configuration-tutorials/programs/
+# @example
+#   haproxy::program { 'hello':
+#     command => 'hello world',
+#   }
+define haproxy::program (
+  String                          $command,
+  Optional[String]                $user        = undef,
+  Optional[String]                $group       = undef,
+  Optional[String]                $options     = undef,
+  String                          $instance    = 'haproxy',
+  Optional[Stdlib::Absolutepath]  $config_file = undef,
+) {
+  # We derive these settings so that the caller only has to specify $instance.
+  include haproxy::params
+
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $_config_file = pick($config_file, $haproxy::config_file)
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $_config_file = pick($config_file, inline_template($haproxy::params::config_file_tmpl))
+  }
+
+  concat::fragment { "${instance_name}-${name}_program":
+    order   => "40-program-${name}",
+    target  => $_config_file,
+    content => epp('haproxy/haproxy_program.epp', {
+      'name'    => $name,
+      'command' => $command,
+      'user'    => $user,
+      'group'   => $group,
+      'options' => $options,
+    }),
+  }
+}

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -1,7 +1,18 @@
 # @summary Program definition
 #
-# A command to be executed by haproxy master process
-#
+# @param command
+#   A command to be executed by haproxy master process
+# @param user
+#   User account used for executing command
+# @param group
+#   Assigned group
+# @param options
+#   By default, the process manager stops and recreates child programs at haproxy reload.
+#   In order to disable this, set this parameter to `no option start-on-reload`
+# @param instance
+#   haproxy instance
+# @param config_file
+#   Path to haproxy config
 # @see https://www.haproxy.com/documentation/haproxy-configuration-tutorials/programs/
 # @example
 #   haproxy::program { 'hello':
@@ -30,11 +41,11 @@ define haproxy::program (
     order   => "40-program-${name}",
     target  => $_config_file,
     content => epp('haproxy/haproxy_program.epp', {
-      'name'    => $name,
-      'command' => $command,
-      'user'    => $user,
-      'group'   => $group,
-      'options' => $options,
+        'name'    => $name,
+        'command' => $command,
+        'user'    => $user,
+        'group'   => $group,
+        'options' => $options,
     }),
   }
 }

--- a/spec/classes/haproxy_spec.rb
+++ b/spec/classes/haproxy_spec.rb
@@ -687,4 +687,31 @@ describe 'haproxy', type: :class do
       }.to raise_error(Puppet::Error, %r{operating system is not supported with the haproxy module})
     end
   end
+
+  describe 'when programs is specified' do
+    ['Debian'].each do |osfamily|
+      context "when on #{osfamily} family operatingsystems" do
+        let(:facts) do
+          { os: { family: osfamily } }.merge default_facts
+        end
+        let(:contents) { param_value(catalogue, 'concat::fragment', 'haproxy-haproxy-base', 'content').split("\n") }
+        let(:params) do
+          {
+            'programs' => {
+              'foo' => {
+                'command' => '/usr/bin/foo',
+              },
+              'bar' => {
+                'command' => '/usr/bin/bar',
+              },
+            },
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_concat__fragment('haproxy-foo_program').with_content(%r{command /usr/bin/foo}) }
+        it { is_expected.to contain_concat__fragment('haproxy-bar_program').with_content(%r{command /usr/bin/bar}) }
+      end
+    end
+  end
 end

--- a/spec/defines/program_spec.rb
+++ b/spec/defines/program_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'haproxy::program' do
+  let :pre_condition do
+    'class{"haproxy":
+        config_file => "/tmp/haproxy.cfg"
+     }
+    '
+  end
+  let(:facts) do
+    {
+      concat_basedir: '/foo',
+      os: {
+        family: 'Debian'
+      }
+    }
+  end
+
+  context 'simple program' do
+    let(:title) { 'hello' }
+    let(:params) do
+      {
+        command: 'echo "hello world"',
+      }
+    end
+
+    it {
+      is_expected.to contain_concat__fragment('haproxy-hello_program').with(
+        'order' => '40-program-hello',
+        'target' => '/tmp/haproxy.cfg',
+        'content' => %r{command echo "hello world"},
+      )
+    }
+  end
+end

--- a/templates/haproxy_program.epp
+++ b/templates/haproxy_program.epp
@@ -1,0 +1,11 @@
+program <%= $name %>
+  command <%= $command %>
+  <% if $user { -%>
+  user <%= $user %>
+  <% } -%>
+  <% if $group { -%>
+  group $group
+  <% } -%>
+  <% if $options { -%>
+  <%= $options %>
+  <% } -%>

--- a/templates/haproxy_program.epp
+++ b/templates/haproxy_program.epp
@@ -4,7 +4,7 @@ program <%= $name %>
   user <%= $user %>
   <% } -%>
   <% if $group { -%>
-  group $group
+  group <%= $group %>
   <% } -%>
   <% if $options { -%>
   <%= $options %>

--- a/types/programs.pp
+++ b/types/programs.pp
@@ -1,0 +1,9 @@
+type Haproxy::Programs = Hash[String, Struct[{
+  command               => String[1],
+  Optional[user]        => String[1],
+  Optional[group]       => String[1],
+  Optional[options]     => String[1],
+  Optional[instance]    => String[1],
+  Optional[config_file] => Stdlib::Absolutepath,
+}]]
+


### PR DESCRIPTION
## Summary

Support running programs executed by main haproxy process as [described in docs](https://www.haproxy.com/documentation/haproxy-configuration-tutorials/programs/). At least `haproxy` version `2.0` is required.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)