### PR TITLE
Eliminate Workaround for Sensitive Data

### DIFF
--- a/manifests/userlist.pp
+++ b/manifests/userlist.pp
@@ -50,8 +50,6 @@ define haproxy::userlist (
       epp_section_name => $section_name,
     },
   )
-  # we have to unwrap here, as "concat" cannot handle Sensitive Data
-  $_content = if $content =~ Sensitive { $content.unwrap } else { $content }
 
   if $instance == 'haproxy' {
     $instance_name = 'haproxy'
@@ -64,6 +62,6 @@ define haproxy::userlist (
   concat::fragment { "${instance_name}-${section_name}_userlist_block":
     order   => "12-${section_name}-00",
     target  => $_config_file,
-    content => $_content,
+    content => $content,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.3 < 11.0.0"
+      "version_requirement": ">= 7.4.0 < 11.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/defines/userlist_spec.rb
+++ b/spec/defines/userlist_spec.rb
@@ -36,7 +36,7 @@ describe 'haproxy::userlist' do
       is_expected.to contain_concat__fragment('haproxy-admins_userlist_block').with(
         'order' => '12-admins-00',
         'target' => '/etc/haproxy/haproxy.cfg',
-        'content' => "\nuserlist admins\n  group superadmins users kitchen scott\n  group megaadmins users kitchen\n  user scott insecure-password elgato\n  user kitchen insecure-password foobar\n",
+        'content' => sensitive("\nuserlist admins\n  group superadmins users kitchen scott\n  group megaadmins users kitchen\n  user scott insecure-password elgato\n  user kitchen insecure-password foobar\n"), # rubocop:disable Layout/LineLength
       )
     }
   end

--- a/templates/haproxy_userlist_block.epp
+++ b/templates/haproxy_userlist_block.epp
@@ -14,12 +14,9 @@ userlist <%= $epp_section_name %>
     }
   }
   $epp_users.each |Variant[String, Sensitive[String]] $user| {
-    # TODO: remove this Workaround, as soon as Function empty() can handle
-    # Sensitive (Pullrequest pending)
-    $user_unsensitive = if $user =~ Sensitive { $user.unwrap } else { $user }
-    unless $user_unsensitive.empty {
+    unless $user.empty {
 -%>
-  user <%= $user_unsensitive %>
+  user <%= $user %>
 <%-
     }
   }


### PR DESCRIPTION
## Summary
Eliminate Workaround for Sensitive Data

## Additional Context
"concat" handles sensitive Data since 7.4.0.
"empty" in Puppet-Core handles sensitive Data since Puppet 7.9.0.

## Related Issues (if any)
fixes 4287df8549421baf15716ddc7ea7540fe9e1bd93

## Checklist
- [ ] 🟢 `pdk validate`
- [ ] 🟢 `pdk test unit`