### PR TITLE
remove stats as default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,6 @@ class haproxy::params {
       }
       $defaults_options  = {
         'log'     => 'global',
-        'stats'   => 'enable',
         'option'  => ['redispatch'],
         'retries' => '3',
         'timeout' => [

--- a/spec/acceptance/defaults_spec.rb
+++ b/spec/acceptance/defaults_spec.rb
@@ -13,7 +13,6 @@ describe 'frontend backend defines with defaults' do
           option => [
             'redispatch',
           ],
-          'stats'   => 'enable',
           'log'     => 'global',
           retries => 3,
           'timeout client' => '3s',
@@ -72,7 +71,6 @@ describe 'frontend backend defines with defaults' do
           option => [
             'redispatch',
           ],
-          'stats'   => 'enable',
           'log'     => 'global',
           retries => 3,
           'timeout client' => '3s',

--- a/spec/defines/defaults_spec.rb
+++ b/spec/defines/defaults_spec.rb
@@ -55,7 +55,6 @@ describe 'haproxy::defaults' do
         maxconn 8000
         option redispatch
         retries 3
-        stats enable
         timeout http-request 10s
         timeout queue 1m
         timeout connect 10s


### PR DESCRIPTION
Fix for #590

This is not a default parameter from Haproxy, and is bad practice to open up stats to all.
This is also not enabled on BSD.