### PR TITLE
Add support for cache

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -18,6 +18,8 @@
 haproxy.cfg file on an haproxy load balancer.
 * [`haproxy::balancermember`](#haproxy--balancermember): This type will setup a balancer member inside a listening service
 configuration block in /etc/haproxy/haproxy.cfg on the load balancer.
+* [`haproxy::cache`](#haproxy--cache): Manage a HAProxy cache resource as documented in
+https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#6
 * [`haproxy::defaults`](#haproxy--defaults): This type will setup a additional defaults configuration block inside the
 haproxy.cfg file on an haproxy load balancer.
 * [`haproxy::frontend`](#haproxy--frontend): This type will setup a frontend service configuration block inside
@@ -707,6 +709,79 @@ Data type: `Enum['server', 'default-server', 'server-template']`
 Optional. Defaults to 'server'
 
 Default value: `'server'`
+
+### <a name="haproxy--cache"></a>`haproxy::cache`
+
+Manage a HAProxy cache resource as documented in
+https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#6
+
+#### Parameters
+
+The following parameters are available in the `haproxy::cache` defined type:
+
+* [`name`](#-haproxy--cache--name)
+* [`total_max_size`](#-haproxy--cache--total_max_size)
+* [`max_object_size`](#-haproxy--cache--max_object_size)
+* [`max_age`](#-haproxy--cache--max_age)
+* [`process_vary`](#-haproxy--cache--process_vary)
+* [`max_secondary_entries`](#-haproxy--cache--max_secondary_entries)
+* [`instance`](#-haproxy--cache--instance)
+
+##### <a name="-haproxy--cache--name"></a>`name`
+
+Name of the cache.
+
+##### <a name="-haproxy--cache--total_max_size"></a>`total_max_size`
+
+Data type: `Integer[1,4095]`
+
+Size of cache in megabytes. Maximum value is 4095.
+
+##### <a name="-haproxy--cache--max_object_size"></a>`max_object_size`
+
+Data type: `Optional[Integer]`
+
+Maximum size of object to be cached. Must not be bigger than half of total_max_size.
+If not set, it equals to 1/256th of total cache size.
+
+Default value: `undef`
+
+##### <a name="-haproxy--cache--max_age"></a>`max_age`
+
+Data type: `Integer`
+
+Maximum expiration time in seconds. The expiration is set as the lowest
+value between the s-maxage or max-age (in this order) directive in the
+Cache-Control response header and this value.
+
+Default value: `60`
+
+##### <a name="-haproxy--cache--process_vary"></a>`process_vary`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+Available since HAProxy 2.4. Turn on or off the processing of the Vary header
+in a response. For more info, check https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#6.2.1-process-vary
+
+Default value: `undef`
+
+##### <a name="-haproxy--cache--max_secondary_entries"></a>`max_secondary_entries`
+
+Data type: `Optional[Integer[1]]`
+
+Available since HAProxy 2.4. Define the maximum number of simultaneous secondary
+entries with the same primary key in the cache. This needs the vary support to
+be enabled. Its default value is 10 and should be passed a strictly positive integer.
+
+Default value: `undef`
+
+##### <a name="-haproxy--cache--instance"></a>`instance`
+
+Data type: `String`
+
+Optional. Defaults to 'haproxy'.
+
+Default value: `'haproxy'`
 
 ### <a name="haproxy--defaults"></a>`haproxy::defaults`
 

--- a/manifests/cache.pp
+++ b/manifests/cache.pp
@@ -1,0 +1,52 @@
+# @summary
+#   Manage a HAProxy cache resource as documented in
+#   https://www.haproxy.com/documentation/haproxy-configuration-manual/2-4r1/#6
+#
+# @param name
+#   Name of the cache.
+#
+# @param total_max_size
+#   Size of cache in megabytes. Maximum value is 4095.
+#
+# @param max_object_size
+#   Maximum size of object to be cached. Must not be bigger than half of total_max_size.
+#   If not set, it equals to 1/256th of total cache size.
+#
+# @param max_age
+#   Maximum expiration time in seconds. The expiration is set as the lowest
+#   value between the s-maxage or max-age (in this order) directive in the
+#   Cache-Control response header and this value.
+#
+# @param instance
+#   Optional. Defaults to 'haproxy'.
+#
+define haproxy::cache (
+  Integer[1,4095] $total_max_size,
+  Optional[Integer] $max_object_size = undef,
+  Integer $max_age = 60,
+  # Integer $max_secondary_entries
+  String  $instance                 = 'haproxy',
+) {
+  include haproxy::params
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $config_file = $haproxy::config_file
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $config_file = inline_template($haproxy::params::config_file_tmpl)
+  }
+
+  $parameters = {
+    'name'            => $name,
+    'total_max_size'  => $total_max_size,
+    'max_object_size' => $max_object_size,
+    'max_age'         => $max_age,
+  }
+
+  # Templates uses $ipaddresses, $server_name, $ports, $option
+  concat::fragment { "${instance_name}-cache-${name}":
+    order   => "40-cache-${name}",
+    target  => $config_file,
+    content => epp('haproxy/haproxy_cache_block.epp', $parameters),
+  }
+}

--- a/spec/defines/cache_spec.rb
+++ b/spec/defines/cache_spec.rb
@@ -32,7 +32,7 @@ describe 'haproxy::cache' do
 
     it {
       is_expected.to contain_concat__fragment('haproxy-cache-dero').with(
-        'order' => '40-cache-dero',
+        'order' => '30-cache-dero',
         'target' => '/tmp/haproxy.cfg',
         'content' => "\ncache dero\n  total-max-size 1\n  max-age 60\n",
       )

--- a/spec/defines/cache_spec.rb
+++ b/spec/defines/cache_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'haproxy::cache' do
+  let :pre_condition do
+    'class{"haproxy":
+        config_file => "/tmp/haproxy.cfg"
+     }
+    '
+  end
+  let(:title) { 'dero' }
+  let(:facts) do
+    {
+      networking: {
+        ip: '1.1.1.1',
+        hostname: 'dero'
+      },
+      concat_basedir: '/foo',
+      os: {
+        family: 'RedHat'
+      }
+    }
+  end
+
+  context 'with a single cache entry' do
+    let(:params) do
+      {
+        total_max_size: 1
+      }
+    end
+
+    it {
+      is_expected.to contain_concat__fragment('haproxy-cache-dero').with(
+        'order' => '40-cache-dero',
+        'target' => '/tmp/haproxy.cfg',
+        'content' => "\ncache dero\n  total-max-size 1\n  max-age 60\n",
+      )
+    }
+  end
+end

--- a/templates/haproxy_cache.epp
+++ b/templates/haproxy_cache.epp
@@ -4,6 +4,10 @@ cache <%= $name %>
 <% if $max_object_size { -%>
   max-object-size <%= $max_object_size %>
 <% } -%>
-<% if $max_age { -%>
   max-age <%= $max_age %>
+<% if $process_vary { -%>
+  process-vary <%= $process_vary %>
+<% } -%>
+<% if $max_secondary_entries { -%>
+  max-secondary-entries <%= $max_secondary_entries %>
 <% } -%>

--- a/templates/haproxy_cache_block.epp
+++ b/templates/haproxy_cache_block.epp
@@ -1,0 +1,9 @@
+
+cache <%= $name %>
+  total-max-size <%= $total_max_size %>
+<% if $max_object_size { -%>
+  max-object-size <%= $max_object_size %>
+<% } -%>
+<% if $max_age { -%>
+  max-age <%= $max_age %>
+<% } -%>


### PR DESCRIPTION
## Summary

This PR adds support for HAProxy cache. All options are supported (https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#6).

## Additional Context

I did some simple testing with puppet apply and from the looks of it, it works as it should. 

I'm not sure how to go about default values. Should they be set with haproxy defaults or left undef as they can change on haproxy side.

## Related Issues (if any)
- https://github.com/puppetlabs/puppetlabs-haproxy/issues/582

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)