### PR TITLE
Add param package_manage

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -111,6 +111,7 @@ class { 'haproxy':
 The following parameters are available in the `haproxy` class:
 
 * [`package_ensure`](#-haproxy--package_ensure)
+* [`package_manage`](#-haproxy--package_manage)
 * [`package_name`](#-haproxy--package_name)
 * [`service_ensure`](#-haproxy--service_ensure)
 * [`service_manage`](#-haproxy--service_manage)
@@ -138,6 +139,15 @@ Ensure the package is present (installed), absent or a specific version.
 Defaults to 'present'
 
 Default value: `'present'`
+
+##### <a name="-haproxy--package_manage"></a>`package_manage`
+
+Data type: `Boolean`
+
+Decide whether the module should manage the installation of
+haproxy package. Defaults to true
+
+Default value: `true`
 
 ##### <a name="-haproxy--package_name"></a>`package_name`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,10 @@
 #  from all balancer members.
 #
 #
+# @param package_manage
+#   Decide whether the module should manage the installation of
+#   haproxy package. Defaults to true
+#
 # @param package_ensure
 #   Ensure the package is present (installed), absent or a specific version.
 #   Defaults to 'present'
@@ -121,6 +125,7 @@
 #
 class haproxy (
   Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]] $package_ensure = 'present',
+  Boolean                                       $package_manage       = true,
   String                                        $package_name         = $haproxy::params::package_name,
   Variant[Enum['running', 'stopped'], Boolean]  $service_ensure       = 'running',
   Boolean                                       $service_manage       = true,
@@ -174,6 +179,7 @@ class haproxy (
   }
 
   haproxy::instance { $title:
+    package_manage      => $package_manage,
     package_ensure      => $_package_ensure,
     package_name        => $package_name,
     service_ensure      => $_service_ensure,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,6 +2,7 @@
 #   Install haproxy
 # @api private
 define haproxy::install (
+  Boolean $package_manage,
   # lint:ignore:140chars
   Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]] $package_ensure,
   Optional[String]  $package_name     = undef,  # A default is required for Puppet 2.7 compatibility. When 2.7 is no longer supported, this parameter default should be removed.
@@ -11,7 +12,7 @@ define haproxy::install (
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $package_name != undef {
+  if $package_manage {
     package { $package_name:
       ensure => $package_ensure,
       alias  => 'haproxy',

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -10,6 +10,9 @@
 #   uses storeconfigs on the Puppet Server to export/collect resources
 #   from all balancer members.
 #
+# @param package_manage
+#   Decide whether the module should manage the installation of
+#   haproxy package. Defaults to true
 #
 # @param package_ensure
 #   Ensure the package is present (installed), absent or a specific version.
@@ -160,6 +163,7 @@
 #
 define haproxy::instance (
   Variant[Enum['present', 'absent', 'purged', 'disabled', 'installed', 'latest'], String[1]] $package_ensure = 'present',
+  Boolean                                      $package_manage       = true,
   Optional[String]                             $package_name         = undef,
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure       = 'running',
   Boolean                                      $service_manage       = true,
@@ -223,6 +227,7 @@ define haproxy::instance (
     config_validate_cmd => $config_validate_cmd,
   }
   haproxy::install { $title:
+    package_manage => $package_manage,
     package_name   => $package_name,
     package_ensure => $package_ensure,
   }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -503,6 +503,94 @@ describe 'haproxy::instance' do
           end
         end
 
+        context "when on #{osfamily} family operatingsystems without managing the package" do
+          let(:facts) do
+            { os: { family: osfamily } }.merge default_facts
+          end
+          let(:params) do
+            {
+              'package_ensure' => 'present',
+              'package_name'   => 'customhaproxy',
+              'package_manage' => false,
+              'service_ensure' => 'running',
+
+            }
+          end
+
+          it 'does not manage the customhaproxy package' do
+            subject.should_not contain_package('customhaproxy').with(
+              'ensure' => 'present',
+            )
+          end
+
+          it 'installs the customhaproxy service' do
+            subject.should contain_service('haproxy-group1').with(
+              'ensure' => 'running', 'enable' => 'true',
+              'hasrestart' => 'true', 'hasstatus' => 'true'
+            )
+          end
+
+          it 'sets up /etc/haproxy-group1/haproxy-group1.cfg as a concat resource' do
+            subject.should contain_concat('/etc/haproxy-group1/haproxy-group1.cfg').with(
+              'owner' => '0',
+              'group' => '0',
+              'mode' => '0640',
+            )
+          end
+
+          it 'manages the chroot directory' do
+            subject.should contain_file('/var/lib/haproxy').with(
+              'ensure' => 'directory',
+            )
+          end
+
+          it 'contains a header concat fragment' do
+            subject.should contain_concat__fragment('haproxy-group1-00-header').with(
+              'target' => '/etc/haproxy-group1/haproxy-group1.cfg',
+              'order' => '01',
+              'content' => "# This file is managed by Puppet\n",
+            )
+          end
+
+          it 'contains a haproxy-group1-haproxy-base concat fragment' do
+            subject.should contain_concat__fragment('haproxy-group1-haproxy-base').with(
+              'target' => '/etc/haproxy-group1/haproxy-group1.cfg',
+              'order' => '10',
+            )
+          end
+
+          describe 'Base concat fragment contents' do
+            let(:contents) { param_value(catalogue, 'concat::fragment', 'haproxy-group1-haproxy-base', 'content').split("\n") }
+
+            it 'contains global and defaults sections' do
+              contents.should include('global')
+              contents.should include('defaults')
+            end
+
+            it 'logs to an ip address for local0' do
+              contents.should be_any do |match|
+                match =~ %r{  log  \d+(\.\d+){3} local0}
+              end
+            end
+
+            it 'specifies the default chroot' do
+              contents.should include('  chroot  /var/lib/haproxy')
+            end
+
+            it 'specifies the correct user' do
+              contents.should include('  user  haproxy')
+            end
+
+            it 'specifies the correct group' do
+              contents.should include('  group  haproxy')
+            end
+
+            it 'specifies the correct pidfile' do
+              contents.should include('  pidfile  /var/run/haproxy.pid')
+            end
+          end
+        end
+
         context "when on #{osfamily} when specifying a restart_command" do
           let(:facts) do
             { os: { family: osfamily } }.merge default_facts


### PR DESCRIPTION
## Summary
Currently it is not possible to skip package installation. 

## Additional Context
This MR adds param `$package_manage`, which lets the user decide on package mgmt.

## Related Issues (if any)
Currently none, but I can file an issue, if wanted...

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)