### PR TITLE
examples: disable default stats listener

### DIFF
--- a/examples/init.pp
+++ b/examples/init.pp
@@ -13,7 +13,6 @@ class { 'haproxy':
   },
   defaults_options => {
     'log'     => 'global',
-    'stats'   => 'enable',
     'option'  => 'redispatch',
     'retries' => '3',
     'timeout' => [
@@ -61,6 +60,7 @@ haproxy::listen { 'stats':
   options   => {
     'mode'  => 'http',
     'stats' => [
+      'enable',
       'uri /',
       'auth puppet:puppet',
     ],


### PR DESCRIPTION
The examples setup a default stats listener. This will add the `/stats` page to all frontends and expose sensitive information like the amount of backends, haproxy version, internal IP addresses and FQDNs.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)