### PR TITLE
Drop RedHat-7 from acceptance matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,5 @@ jobs:
        contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: '--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7'
+      flags: '--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude redhat-7'
     secrets: "inherit"

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -42,7 +42,7 @@ RSpec.configure do |c|
     # Make sure selinux is disabled so the tests work.
     LitmusHelper.instance.run_shell('setenforce 0', expect_failures: true) if os[:family].match?(%r{redhat|oracle})
 
-    if os[:family] == 'redhat' && os[:release].to_i != 8
+    if os[:family] == 'redhat' && [9].include?(os[:release].to_i)
       epel_owner = 'puppet'
       LitmusHelper.instance.run_shell("puppet module install #{epel_owner}/epel")
       LitmusHelper.instance.run_shell("puppet apply -e 'include epel'")


### PR DESCRIPTION
## Summary

- Adds `--platform-exclude redhat-7` to `ci.yml` flags alongside the other already-excluded EL7 platforms (CentOS-7, Scientific-7, OracleLinux-7)
- Tightens the epel setup condition in `spec_helper_acceptance_local.rb` from `os[:release].to_i != 8` to `[9].include?(os[:release].to_i)`, explicitly listing the releases that need EPEL rather than relying on exclusion logic

## Root cause

RHEL 7 reached EOL in June 2024. `puppet/epel` 6.0.0 (released 2026-01-15) dropped EL7 support and removed `RPM-GPG-KEY-EPEL-7`, breaking the acceptance test setup which installs the module unpinned.

## Test plan

- [x] RedHat-7 no longer appears in the acceptance matrix
- [x] RedHat-9 acceptance tests still pass (epel setup still runs for RHEL 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)