### PR TITLE
Move 8.2.1 withdrawal note from CHANGELOG.md to HISTORY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-haproxy/compare/v8.2.0...v9.0.0)
 
-> **Note:** This release supersedes and corrects the withdrawn `8.2.1`, which was mistakenly published as a patch despite dropping Puppet 7 support. `8.2.1` has been removed from the Puppet Forge; use `9.0.0` instead.
-
 ### Changed
 
 - **Remove Puppet 7 support; the module now requires `puppet >= 8.0.0 < 9.0.0`** [#631](https://github.com/puppetlabs/puppetlabs-haproxy/pull/631) ([gavindidrichsen](https://github.com/gavindidrichsen))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 8.2.1 (Withdrawn)
+### Summary
+This version was mistakenly published as a patch release despite dropping Puppet 7 support, a backwards-incompatible change. It has been removed from the Puppet Forge and superseded by `9.0.0`, which correctly reflects this change as a major version bump. Do not use `8.2.1`.
+
 ## 2.1.0
 ### Summary
 This release uses the PDK convert functionality which in return makes the module PDK compliant. It also includes a roll up of maintenance changes.


### PR DESCRIPTION
## Summary
- The release-prep automation (`gh changelog new`) regenerates `CHANGELOG.md` wholesale from git tags/PRs each release. It drops the hand-written note under `v9.0.0` explaining that `8.2.1` was mistakenly published as a patch (despite dropping Puppet 7 support) and was withdrawn from the Forge.
- Worse: since the `v8.2.1` git tag still exists, the regenerator resurrects a `## [v8.2.1]` section on the next run as if it were a normal release, with no indication it was pulled — confirmed by testing the actual release-prep workflow (see the now-closed #648).
- This moves that context into `HISTORY.md` (which isn't touched by release-prep) as a `## 8.2.1 (Withdrawn)` entry, and removes the note from `CHANGELOG.md` since it would be stripped by automation anyway.

## Test plan
- [x] Confirmed via the closed release-prep PR (#648) that `gh changelog new` drops the note and reintroduces a bare `v8.2.1` section.
- [x] `HISTORY.md` change is additive only; `CHANGELOG.md` change is a two-line removal, no other content touched.