### PR TITLE
Add haproxy::http_errors and haproxy::ring resources

### DIFF
--- a/manifests/http_errors.pp
+++ b/manifests/http_errors.pp
@@ -1,0 +1,57 @@
+# @summary
+#   This type will set up a HTTP error group configuration block inside the haproxy.cfg
+#   file on an haproxy load balancer.
+#
+# @note
+#   See https://docs.haproxy.org/2.2/configuration.html#3.8 for more info
+#
+# @note
+#   Currently requires the puppetlabs/concat module on the Puppet Forge
+#
+#
+# @param section_name
+#    This name goes right after the http-errors' statement in haproxy.cfg
+#    Default: $name (the namevar of the resource).
+#
+# @param errorfile
+#   Mapping of HTTP status codes to response files.
+#   See https://docs.haproxy.org/2.2/configuration.html#3.8-errorfile
+#   $errorfile = { 404 => '/usr/share/haproxy/errors/40x.html' }
+#
+# @param config_file
+#   Optional. Path of the config file where this entry will be added.
+#   Assumes that the parent directory exists.
+#   Default: $haproxy::params::config_file
+#
+# @param instance
+#   Optional. Defaults to 'haproxy'
+#
+define haproxy::http_errors (
+  String[1]                           $section_name = $name,
+  String                              $instance     = 'haproxy',
+  Optional[Stdlib::Absolutepath]      $config_file  = undef,
+  Hash[Integer, Stdlib::Absolutepath] $errorfile    = {},
+) {
+  include haproxy::params
+
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $_config_file  = pick($config_file, $haproxy::config_file)
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $_config_file  = pick($config_file, inline_template($haproxy::params::config_file_tmpl))
+  }
+
+  assert_type(Stdlib::AbsolutePath, dirname($_config_file))
+
+  $parameters = {
+    section_name => $section_name,
+    errorfile    => $errorfile,
+  }
+
+  concat::fragment { "${instance_name}-${section_name}_http_errors_block":
+    order   => "16-${section_name}-00",
+    target  => $_config_file,
+    content => epp('haproxy/haproxy_http_errors_block.epp', $parameters),
+  }
+}

--- a/manifests/ring.pp
+++ b/manifests/ring.pp
@@ -1,0 +1,87 @@
+# @summary
+#   This type will set up a ring-buffer configuration block inside the haproxy.cfg
+#   file on an haproxy load balancer.
+#
+# @note
+#   See https://docs.haproxy.org/2.2/configuration.html#3.9 for more info
+#
+# @note
+#   Currently requires the puppetlabs/concat module on the Puppet Forge
+#
+#
+# @param section_name
+#    This name goes right after the 'ring' statement in haproxy.cfg
+#    Default: $name (the namevar of the resource).
+#
+# @param description
+#   Descriptive message for the CLI.
+#   See https://docs.haproxy.org/2.2/configuration.html#3.9-description
+#
+# @param format
+#   Format used to store events into the ring buffer.
+#   See https://docs.haproxy.org/2.2/configuration.html#3.9-format
+#
+# @param maxlen
+#   The maximum length of an event message stored into the ring.
+#   See https://docs.haproxy.org/2.2/configuration.html#3.9-maxlen
+#
+# @param size
+#   Ring buffer size.
+#   See https://docs.haproxy.org/2.2/configuration.html#3.9-size
+#
+# @param timeout
+#   Hash of timeout for various phases of the write operation
+#   $timeout = { 'connect' => '10s', 'server' => '5s' }
+#
+# @param server
+#   Mapping of Syslog TCP server names to address (and optional parameters).
+#   See https://docs.haproxy.org/2.2/configuration.html#3.9-server
+#   $server = { 'mysyslogsrv' => '127.0.0.1:6514 log-proto octet-count' }
+#
+# @param config_file
+#   Optional. Path of the config file where this entry will be added.
+#   Assumes that the parent directory exists.
+#   Default: $haproxy::params::config_file
+#
+# @param instance
+#   Optional. Defaults to 'haproxy'
+#
+define haproxy::ring (
+  String[1]                             $section_name = $name,
+  String                                $instance     = 'haproxy',
+  Optional[Stdlib::Absolutepath]        $config_file  = undef,
+  Optional[String[1]]                   $description  = undef,
+  Optional[Haproxy::Ring_buffer_format] $format       = undef,
+  Optional[Integer[1]]                  $maxlen       = undef,
+  Optional[Integer[1]]                  $size         = undef,
+  Hash                                  $timeout      = {},
+  Hash                                  $server       = {},
+) {
+  include haproxy::params
+
+  if $instance == 'haproxy' {
+    $instance_name = 'haproxy'
+    $_config_file  = pick($config_file, $haproxy::config_file)
+  } else {
+    $instance_name = "haproxy-${instance}"
+    $_config_file  = pick($config_file, inline_template($haproxy::params::config_file_tmpl))
+  }
+
+  assert_type(Stdlib::AbsolutePath, dirname($_config_file))
+
+  $parameters = {
+    section_name => $section_name,
+    description  => $description,
+    format       => $format,
+    maxlen       => $maxlen,
+    size         => $size,
+    timeout      => $timeout,
+    server       => $server,
+  }
+
+  concat::fragment { "${instance_name}-${section_name}_ring_block":
+    order   => "17-${section_name}-00",
+    target  => $_config_file,
+    content => epp('haproxy/haproxy_ring_block.epp', $parameters),
+  }
+}

--- a/spec/defines/http_errors_spec.rb
+++ b/spec/defines/http_errors_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'haproxy::http_errors' do
+  let(:pre_condition) { 'include haproxy' }
+  let(:title) { 'spec' }
+  let(:facts) do
+    {
+      networking: {
+        ip: '1.1.1.1'
+      },
+      os: {
+        family: 'Redhat'
+      },
+      concat_basedir: '/dne'
+    }
+  end
+
+  context 'when error files are configured' do
+    let(:params) do
+      {
+        errorfile: {
+          400 => '/etc/haproxy/errorfiles/400.http',
+          404 => '/etc/haproxy/errorfiles/404.http',
+          408 => '/dev/null',
+        },
+      }
+    end
+    let(:assertion) do
+      <<-CFG
+
+http-errors spec
+  errorfile 400 /etc/haproxy/errorfiles/400.http
+  errorfile 404 /etc/haproxy/errorfiles/404.http
+  errorfile 408 /dev/null
+CFG
+    end
+
+    it {
+      is_expected.to contain_concat__fragment('haproxy-spec_http_errors_block').with(
+        'order' => '16-spec-00',
+        'target' => '/etc/haproxy/haproxy.cfg',
+        'content' => assertion,
+      )
+    }
+  end
+
+  context 'when a non-default config file is used' do
+    let(:pre_condition) { 'class { "haproxy": config_file => "/etc/non-default.cfg" }' }
+    let(:params) do
+      {
+        name: 'bar',
+        errorfile: {
+          404 => '/usr/share/haproxy/errorfiles/404.http',
+          503 => '/usr/share/haproxy/errorfiles/503.http',
+        },
+      }
+    end
+    let(:assertion) do
+      <<-CFG
+
+http-errors bar
+  errorfile 404 /usr/share/haproxy/errorfiles/404.http
+  errorfile 503 /usr/share/haproxy/errorfiles/503.http
+CFG
+    end
+
+    it {
+      is_expected.to contain_concat__fragment('haproxy-bar_http_errors_block').with(
+        'order' => '16-bar-00',
+        'target' => '/etc/non-default.cfg',
+        'content' => assertion,
+      )
+    }
+  end
+end

--- a/spec/defines/ring_spec.rb
+++ b/spec/defines/ring_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'haproxy::ring' do
+  let(:pre_condition) { 'include haproxy' }
+  let(:title) { 'spec' }
+  let(:facts) do
+    {
+      networking: {
+        ip: '1.1.1.1'
+      },
+      os: {
+        family: 'Redhat'
+      },
+      concat_basedir: '/dne'
+    }
+  end
+
+  context 'when a server is configured' do
+    let(:params) do
+      {
+        server: {
+          'mysyslogsrv' => '127.0.0.1:6514 log-proto octet-count',
+        },
+      }
+    end
+    let(:assertion) do
+      <<-CFG
+
+ring spec
+  server mysyslogsrv 127.0.0.1:6514 log-proto octet-count
+CFG
+    end
+
+    it {
+      is_expected.to contain_concat__fragment('haproxy-spec_ring_block').with(
+        'order' => '17-spec-00',
+        'target' => '/etc/haproxy/haproxy.cfg',
+        'content' => assertion,
+      )
+    }
+  end
+
+  context 'when timeouts are configured' do
+    let(:params) do
+      {
+        timeout: {
+          'connect' => '10',
+          'resolve' => '3s',
+        },
+      }
+    end
+    let(:assertion) do
+      <<-CFG
+
+ring spec
+  timeout connect 10
+  timeout resolve 3s
+CFG
+    end
+
+    it {
+      is_expected.to contain_concat__fragment('haproxy-spec_ring_block').with(
+        'order' => '17-spec-00',
+        'target' => '/etc/haproxy/haproxy.cfg',
+        'content' => assertion,
+      )
+    }
+  end
+
+  context 'when a non-default config file is used' do
+    let(:pre_condition) { 'class { "haproxy": config_file => "/etc/non-default.cfg" }' }
+    let(:params) do
+      {
+        name: 'bar',
+        format: 'rfc3164',
+      }
+    end
+    let(:assertion) do
+      <<-CFG
+
+ring bar
+  format rfc3164
+CFG
+    end
+
+    it {
+      is_expected.to contain_concat__fragment('haproxy-bar_ring_block').with(
+        'order' => '17-bar-00',
+        'target' => '/etc/non-default.cfg',
+        'content' => assertion,
+      )
+    }
+  end
+end

--- a/spec/type_aliases/haproxy_ring_buffer_format_spec.rb
+++ b/spec/type_aliases/haproxy_ring_buffer_format_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'Haproxy::Ring_buffer_format' do
+  # Valid enum declarations
+  it { is_expected.to allow_value('iso') }
+  it { is_expected.to allow_value('raw') }
+  it { is_expected.to allow_value('rfc3164') }
+  it { is_expected.to allow_value('rfc5424') }
+  it { is_expected.to allow_value('short') }
+  it { is_expected.to allow_value('timed') }
+
+  # Disallowed
+  it { is_expected.not_to allow_value('') }
+  it { is_expected.not_to allow_value(nil) }
+  it { is_expected.not_to allow_value(3399) }
+  it { is_expected.not_to allow_value('monotonic') }
+end

--- a/templates/haproxy_http_errors_block.epp
+++ b/templates/haproxy_http_errors_block.epp
@@ -1,0 +1,5 @@
+
+http-errors <%= $section_name %>
+<% $errorfile.each |$code, $file| { -%>
+  errorfile <%= $code %> <%= $file %>
+<% } -%>

--- a/templates/haproxy_ring_block.epp
+++ b/templates/haproxy_ring_block.epp
@@ -1,0 +1,20 @@
+
+ring <%= $section_name %>
+<% if $description { -%>
+  description <%= $description %>
+<% } -%>
+<% if $format { -%>
+  format <%= $format %>
+<% } -%>
+<% if $maxlen { -%>
+  maxlen <%= $maxlen %>
+<% } -%>
+<% if $size { -%>
+  size <%= $size %>
+<% } -%>
+<% $timeout.each |$event, $time| { -%>
+  timeout <%= $event %> <%= $time %>
+<% } -%>
+<% $server.each |$name, $address| { -%>
+  server <%= $name %> <%= $address %>
+<% } -%>

--- a/types/ring_buffer_format.pp
+++ b/types/ring_buffer_format.pp
@@ -1,0 +1,3 @@
+# @summary Log format for generated syslog messages
+#
+type Haproxy::Ring_buffer_format = Enum['iso', 'raw', 'rfc3164', 'rfc5424', 'short', 'timed']


### PR DESCRIPTION
## Summary

The `http-errors` stanza was introduced with HAproxy 2.2
and allows configuring reusable HTTP error responses.

The `ring` stanza was also introduced with HAproxy 2.2
and allows configuring a ring-buffer for remote log
shipping.

Both new defined types are modeled after existing types
such as `haproxy::userlist`

## Related Issues (if any)

requested in #520

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)